### PR TITLE
improve error handling

### DIFF
--- a/aggregator/apps/api/errors.py
+++ b/aggregator/apps/api/errors.py
@@ -1,0 +1,4 @@
+class ApiError(Exception):
+    def __init__(self, message, status=500):
+        self.message = message
+        self.status = status

--- a/aggregator/apps/api/middleware.py
+++ b/aggregator/apps/api/middleware.py
@@ -1,18 +1,30 @@
 import logging
+import traceback
+from django.conf import settings
+from django.http import JsonResponse
+from .errors import ApiError
 
 logger = logging.getLogger(__name__)
 
 
-class LoggerMiddleware(object):
+class ErrorHandlerMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
-    def __call__(self, request):
-        response = self.get_response(request)
+    def process_exception(self, request, exception):
         if (
-            response.status_code >= 500
+            not settings.DEBUG
             and "/sandbox" not in request.path
             and "/api" in request.path
         ):
-            logger.error(f"{response.status_code} - {response.content}")
-        return response
+            if isinstance(exception, ApiError):
+                if exception.status >= 500:
+                    logger.error(traceback.format_exc())
+                return JsonResponse(
+                    {"message": exception.message}, status=exception.status
+                )
+            logger.error(traceback.format_exc())
+            return JsonResponse({"message": "Internal Server Error"}, status=500)
+
+    def __call__(self, request):
+        return self.get_response(request)

--- a/aggregator/apps/api/v1/api_client.py
+++ b/aggregator/apps/api/v1/api_client.py
@@ -7,7 +7,7 @@ from django.http import QueryDict
 from django.urls import reverse
 
 
-class ApiError(Exception):
+class UpstreamApiError(Exception):
     def __init__(self, status, message):
         self.status = status
         self.message = message
@@ -46,7 +46,7 @@ def proxy_single_request(loop, request):
     loop.run_until_complete(response)
     result = response.result()
     if result["status"] >= 400:
-        raise ApiError(result["status"], result["json"]["detail"])
+        raise UpstreamApiError(result["status"], result["json"]["detail"])
     return result
 
 
@@ -91,9 +91,11 @@ class WdivWcivfApiClient(AsyncApiClient):
         wcivf_result = self.get_wcivf_result(responses)
 
         if wdiv_result["status"] >= 400:
-            raise ApiError(wdiv_result["status"], wdiv_result["json"]["detail"])
+            raise UpstreamApiError(wdiv_result["status"], wdiv_result["json"]["detail"])
         if wcivf_result["status"] >= 400:
-            raise ApiError(wcivf_result["status"], wcivf_result["json"]["detail"])
+            raise UpstreamApiError(
+                wcivf_result["status"], wcivf_result["json"]["detail"]
+            )
 
         return (wdiv_result["json"], wcivf_result["json"])
 
@@ -101,7 +103,7 @@ class WdivWcivfApiClient(AsyncApiClient):
         for r in results:
             if base_url in r["url"]:
                 return r
-        raise ApiError(500, "Internal Server Error")
+        raise UpstreamApiError(500, "Internal Server Error")
 
     def get_wdiv_result(self, results):
         return self.get_result_by_base_url(results, settings.WDIV_BASE_URL)

--- a/aggregator/apps/api/v1/api_client.py
+++ b/aggregator/apps/api/v1/api_client.py
@@ -8,9 +8,9 @@ from django.urls import reverse
 
 
 class UpstreamApiError(Exception):
-    def __init__(self, status, message):
-        self.status = status
+    def __init__(self, message, status):
         self.message = message
+        self.status = status
 
 
 def get_event_loop():
@@ -46,7 +46,7 @@ def proxy_single_request(loop, request):
     loop.run_until_complete(response)
     result = response.result()
     if result["status"] >= 400:
-        raise UpstreamApiError(result["status"], result["json"]["detail"])
+        raise UpstreamApiError(result["json"]["detail"], result["status"])
     return result
 
 
@@ -91,10 +91,10 @@ class WdivWcivfApiClient(AsyncApiClient):
         wcivf_result = self.get_wcivf_result(responses)
 
         if wdiv_result["status"] >= 400:
-            raise UpstreamApiError(wdiv_result["status"], wdiv_result["json"]["detail"])
+            raise UpstreamApiError(wdiv_result["json"]["detail"], wdiv_result["status"])
         if wcivf_result["status"] >= 400:
             raise UpstreamApiError(
-                wcivf_result["status"], wcivf_result["json"]["detail"]
+                wcivf_result["json"]["detail"], wcivf_result["status"]
             )
 
         return (wdiv_result["json"], wcivf_result["json"])
@@ -103,7 +103,7 @@ class WdivWcivfApiClient(AsyncApiClient):
         for r in results:
             if base_url in r["url"]:
                 return r
-        raise UpstreamApiError(500, "Internal Server Error")
+        raise UpstreamApiError("Internal Server Error", 500)
 
     def get_wdiv_result(self, results):
         return self.get_result_by_base_url(results, settings.WDIV_BASE_URL)

--- a/aggregator/apps/api/v1/tests/views/test_base_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_base_view.py
@@ -1,7 +1,7 @@
 import aiohttp
 from unittest.mock import patch
 from django.test import TestCase
-from api.v1.api_client import ApiError
+from api.v1.api_client import UpstreamApiError
 
 
 def aiohttp_error(*args, **kwargs):
@@ -9,7 +9,7 @@ def aiohttp_error(*args, **kwargs):
 
 
 def api_error(*args, **kwargs):
-    raise ApiError(500, "oh noes!!")
+    raise UpstreamApiError(500, "oh noes!!")
 
 
 class BaseViewTests(TestCase):

--- a/aggregator/apps/api/v1/tests/views/test_base_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_base_view.py
@@ -9,7 +9,7 @@ def aiohttp_error(*args, **kwargs):
 
 
 def api_error(*args, **kwargs):
-    raise UpstreamApiError(500, "oh noes!!")
+    raise UpstreamApiError("oh noes!!", 500)
 
 
 class BaseViewTests(TestCase):

--- a/aggregator/settings/base.py
+++ b/aggregator/settings/base.py
@@ -40,7 +40,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "api.middleware.LoggerMiddleware",
+    "api.middleware.ErrorHandlerMiddleware",
 ]
 
 ROOT_URLCONF = "aggregator.urls"


### PR DESCRIPTION
While I was working on the PR for the elections endpoint, I hit a couple of pain points with error handling. One was that uncaught errors were throwing HTML errors instead of being wrapped in JSON. The other was that that logging/wrapping I'd put in place was annoying in dev. I threw something together when we were putting together a MVP, but its time to improve it. This PR fixes those problems (and more) by improving the error handling middleware and allowing us to throw an error response by raising an `ApiError()`.

This achieves several helpful things:

1. Better errors for users: users always get a JSON wrapped error from the "api" bit of the application, even if its an uncaught error. The "website" bit always throws DC Theme-formatted HTML errors.
2. Better errors in sentry. Using `traceback.format_exc()` will give us a full stacktrace for unhandled exceptions or `ApiError` with status >=500 in sentry even though we're wrapping the error.
3. Better errors in dev: if `settings.DEBUG` is True, we'll defer to django's usual local dev error handling for the browser and the console output is more helpful.