### PR TITLE
Add voting system, seats contested and organisation type

### DIFF
--- a/aggregator/apps/api/v1/docs/finder_data_structures.apibp
+++ b/aggregator/apps/api/v1/docs/finder_data_structures.apibp
@@ -63,6 +63,11 @@
                 + `election_name`: `Cardiff local election` (string) - Friendly name for this ballot's parent election group
                 + `post_name`: `Pontprennau/Old St. Mellons` (string) - Name of the division or post the winner(s) of this election will represent
                 + `candidates_verified`: `false` (boolean) - True if the list of candidates for this election has been confirmed against the nomination papers for this ballot. If this property is False, the candidate list is provisional or unconfirmed.
+                + `voting_system` (object) - The voting system used in this election
+                    + `slug`: `FPTP` (string) - One of `AMS`, `FPTP`, `PR-CL`, `sv`, `STV`
+                    + `name`: `First-past-the-post` (string) - The name of this voting system (e.g: "First-past-the-post")
+                    + `uses_party_lists`: `false` (boolean) - True if this voting system uses party lists
+                + `seats_contested`: `1` (number) – The number of candidate who will be elected
                 + candidates: (array[object], fixed-type) - Array of candidate objects describing candidates that will appear on this ballot paper. In an election which uses party lists, the `candidates` array is sorted by party and `list_position` within parties. For other election types it is sorted alphabetically by candidate name.
                     + (object)
                         + `list_position`: (number, nullable) - Numeric position in party list. This value is only relevant to elections using party lists. It will always be null in First-Past-The-post elections.

--- a/aggregator/apps/api/v1/sandbox-responses/AA12AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA12AA.json
@@ -40,6 +40,12 @@
           "election_name": "Westminster local election",
           "post_name": "Lancaster Gate",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,

--- a/aggregator/apps/api/v1/sandbox-responses/AA12AB.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA12AB.json
@@ -26,6 +26,12 @@
           "election_name": "Westminster local election",
           "post_name": "Lancaster Gate",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,

--- a/aggregator/apps/api/v1/sandbox-responses/AA14AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA14AA.json
@@ -26,6 +26,12 @@
           "election_name": "Mayor of Lewisham election",
           "post_name": "London Borough of Lewisham",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "sv",
+            "name": "Supplementary Vote",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,
@@ -142,6 +148,12 @@
               }
           },
           "cancelled": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "replaced_by": "local.lewisham.blackheath.2018-05-10",
           "replaces": null,
           "election_id": "local.lewisham.2018-05-03",
@@ -314,6 +326,12 @@
           "cancelled": false,
           "replaced_by": null,
           "replaces": "local.lewisham.blackheath.2018-05-03",
+          "seats_contested": 1,
+          "voting_system": {
+            "name": "First-past-the-post",
+            "slug": "FPTP",
+            "uses_party_lists": false
+          },
           "election_id": "local.lewisham.2018-05-10",
           "election_name": "Lewisham local election",
           "post_name": "Blackheath",
@@ -488,6 +506,12 @@
           "election_name": "UK Parliament elections",
           "post_name": "Lewisham East",
           "candidates_verified": false,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [],
           "wcivf_url": "https://whocanivotefor.co.uk/elections/parl.2018-06-14/post-WMC:E14000787/lewisham-east"
         }

--- a/aggregator/apps/api/v1/sandbox-responses/AA15AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA15AA.json
@@ -39,6 +39,12 @@
           "election_name": "UK Parliament elections",
           "post_name": "West Tyrone",
           "candidates_verified": false,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [],
           "wcivf_url": "https://whocanivotefor.co.uk/elections/parl.2018-05-03/post-WMC:N06000018/west-tyrone"
         }

--- a/aggregator/apps/api/v1/sandbox-responses/e09000033-2282254634585.json
+++ b/aggregator/apps/api/v1/sandbox-responses/e09000033-2282254634585.json
@@ -40,6 +40,12 @@
           "election_name": "Westminster local election",
           "post_name": "Lancaster Gate",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,

--- a/aggregator/apps/api/v1/sandbox-responses/e09000033-7816246896787.json
+++ b/aggregator/apps/api/v1/sandbox-responses/e09000033-7816246896787.json
@@ -26,6 +26,12 @@
           "election_name": "Westminster local election",
           "post_name": "Lancaster Gate",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,

--- a/aggregator/apps/api/v1/sandbox-responses/e09000033-8531289123599.json
+++ b/aggregator/apps/api/v1/sandbox-responses/e09000033-8531289123599.json
@@ -40,6 +40,12 @@
           "election_name": "Westminster local election",
           "post_name": "Lancaster Gate",
           "candidates_verified": true,
+          "voting_system": {
+            "slug": "FPTP",
+            "name": "First-past-the-post",
+            "uses_party_lists": false
+          },
+          "seats_contested": 1,
           "candidates": [
             {
               "list_position": null,

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -155,6 +155,8 @@ class Stitcher:
                 ballot["candidates_verified"] = wcivf_ballot["ballot_locked"]
                 ballot["candidates"] = wcivf_ballot["candidates"]
                 ballot["wcivf_url"] = wcivf_ballot["absolute_url"]
+                ballot["voting_system"] = wcivf_ballot["voting_system"]
+                ballot["seats_contested"] = wcivf_ballot["seats_contested"]
         if results:
             results[0]["polling_station"] = self.minimal_wdiv_response
         response = {

--- a/aggregator/apps/api/v1/templates/api_docs_rendered.html
+++ b/aggregator/apps/api/v1/templates/api_docs_rendered.html
@@ -327,6 +327,12 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
           &quot;election_name&quot;: &quot;Cardiff local election&quot;,
           &quot;post_name&quot;: &quot;Pontprennau/Old St. Mellons&quot;,
           &quot;candidates_verified&quot;: false,
+          &quot;voting_system&quot;: {
+            &quot;slug&quot;: &quot;FPTP&quot;,
+            &quot;name&quot;: &quot;First-past-the-post&quot;,
+            &quot;uses_party_lists&quot;: false
+          },
+          &quot;seats_contested&quot;: 1,
           &quot;candidates&quot;: [
             {
               &quot;list_position&quot;: null,
@@ -572,6 +578,27 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
                 &quot;candidates_verified&quot;: {
                   &quot;type&quot;: &quot;boolean&quot;,
                   &quot;description&quot;: &quot;True if the list of candidates for this election has been confirmed against the nomination papers for this ballot. If this property is False, the candidate list is provisional or unconfirmed.&quot;
+                },
+                &quot;voting_system&quot;: {
+                  &quot;type&quot;: &quot;object&quot;,
+                  &quot;properties&quot;: {
+                    &quot;slug&quot;: {
+                      &quot;type&quot;: &quot;string&quot;,
+                      &quot;description&quot;: &quot;One of `AMS`, `FPTP`, `PR-CL`, `sv`, `STV`&quot;
+                    },
+                    &quot;name&quot;: {
+                      &quot;type&quot;: &quot;string&quot;,
+                      &quot;description&quot;: &quot;The name of this voting system (e.g: \&quot;First-past-the-post\&quot;)&quot;
+                    },
+                    &quot;uses_party_lists&quot;: {
+                      &quot;type&quot;: &quot;boolean&quot;,
+                      &quot;description&quot;: &quot;True if this voting system uses party lists&quot;
+                    }
+                  },
+                  &quot;description&quot;: &quot;The voting system used in this election&quot;
+                },
+                &quot;seats_contested&quot;: {
+                  &quot;type&quot;: &quot;number&quot;
                 },
                 &quot;candidates&quot;: {
                   &quot;type&quot;: &quot;array&quot;,
@@ -1066,6 +1093,12 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
           &quot;election_name&quot;: &quot;Cardiff local election&quot;,
           &quot;post_name&quot;: &quot;Pontprennau/Old St. Mellons&quot;,
           &quot;candidates_verified&quot;: false,
+          &quot;voting_system&quot;: {
+            &quot;slug&quot;: &quot;FPTP&quot;,
+            &quot;name&quot;: &quot;First-past-the-post&quot;,
+            &quot;uses_party_lists&quot;: false
+          },
+          &quot;seats_contested&quot;: 1,
           &quot;candidates&quot;: [
             {
               &quot;list_position&quot;: null,
@@ -1311,6 +1344,27 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
                 &quot;candidates_verified&quot;: {
                   &quot;type&quot;: &quot;boolean&quot;,
                   &quot;description&quot;: &quot;True if the list of candidates for this election has been confirmed against the nomination papers for this ballot. If this property is False, the candidate list is provisional or unconfirmed.&quot;
+                },
+                &quot;voting_system&quot;: {
+                  &quot;type&quot;: &quot;object&quot;,
+                  &quot;properties&quot;: {
+                    &quot;slug&quot;: {
+                      &quot;type&quot;: &quot;string&quot;,
+                      &quot;description&quot;: &quot;One of `AMS`, `FPTP`, `PR-CL`, `sv`, `STV`&quot;
+                    },
+                    &quot;name&quot;: {
+                      &quot;type&quot;: &quot;string&quot;,
+                      &quot;description&quot;: &quot;The name of this voting system (e.g: \&quot;First-past-the-post\&quot;)&quot;
+                    },
+                    &quot;uses_party_lists&quot;: {
+                      &quot;type&quot;: &quot;boolean&quot;,
+                      &quot;description&quot;: &quot;True if this voting system uses party lists&quot;
+                    }
+                  },
+                  &quot;description&quot;: &quot;The voting system used in this election&quot;
+                },
+                &quot;seats_contested&quot;: {
+                  &quot;type&quot;: &quot;number&quot;
                 },
                 &quot;candidates&quot;: {
                   &quot;type&quot;: &quot;array&quot;,

--- a/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_multiple_elections/wcivf.json
+++ b/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_multiple_elections/wcivf.json
@@ -10,6 +10,13 @@
       "post_name": "London Borough of Lewisham"
     },
     "cancelled": false,
+    "voting_system": {
+      "slug": "sv",
+      "name": "Supplementary Vote",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "local-authority",
     "ballot_locked": true,
     "candidates": [
       {
@@ -124,6 +131,13 @@
       "post_name": "Blackheath"
     },
     "cancelled": true,
+    "voting_system": {
+      "slug": "FPTP",
+      "name": "First-past-the-post",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "local-authority",
     "ballot_locked": true,
     "candidates": [
       {
@@ -280,6 +294,13 @@
       "post_name": "Blackheath"
     },
     "cancelled": false,
+    "voting_system": {
+      "slug": "FPTP",
+      "name": "First-past-the-post",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "local-authority",
     "ballot_locked": false,
     "candidates": [
       {
@@ -436,6 +457,13 @@
       "post_name": "Lewisham East"
     },
     "cancelled": false,
+    "voting_system": {
+      "slug": "FPTP",
+      "name": "First-past-the-post",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "parl",
     "ballot_locked": false,
     "candidates": [],
     "ballot_paper_id": "parl.lewisham-east.by.2018-06-14"

--- a/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_one_election_station_known_with_candidates/wcivf.json
+++ b/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_one_election_station_known_with_candidates/wcivf.json
@@ -10,6 +10,13 @@
       "post_name": "Lancaster Gate"
     },
     "cancelled": false,
+    "voting_system": {
+      "slug": "FPTP",
+      "name": "First-past-the-post",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "local-authority",
     "ballot_locked": true,
     "candidates": [
       {

--- a/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_one_election_station_not_known_with_candidates/wcivf.json
+++ b/aggregator/apps/api/v1/tests/test_data/addresspc_endpoints/test_one_election_station_not_known_with_candidates/wcivf.json
@@ -10,6 +10,13 @@
       "post_name": "Lancaster Gate"
     },
     "cancelled": false,
+    "voting_system": {
+      "slug": "FPTP",
+      "name": "First-past-the-post",
+      "uses_party_lists": false
+    },
+    "seats_contested": 1,
+    "organisation_type": "local-authority",
     "ballot_locked": true,
     "candidates": [
       {


### PR DESCRIPTION
Fixes #125 

I've updated the WCIVF fixtures to add `organisation_type`, even though it's ignored at the moment. Hopefully this will be useful for #124. 

