### PR TITLE
Order elections by charisma

### DIFF
--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -90,14 +90,14 @@ class Stitcher:
     def __init__(self, wdiv_resp, wcivf_resp, request):
         self.wdiv_resp = wdiv_resp
         self.wcivf_resp = wcivf_resp
-        self.wcivf_by_ballot = self.make_wcivf_by_ballot()
+        self.wcivf_ballots = self.make_wcivf_ballots()
         self.ballot_sort_keys = {}
         self.request = request
         self.validate()
 
     def validate(self):
         for ballot in self.wdiv_resp["ballots"]:
-            if ballot["ballot_paper_id"] not in self.wcivf_by_ballot:
+            if ballot["ballot_paper_id"] not in self.wcivf_ballots:
                 raise StitcherValidationError(
                     f'Could not find expected ballot {ballot["ballot_paper_id"]}'
                 )
@@ -119,7 +119,7 @@ class Stitcher:
         council = deepcopy(self.wdiv_resp["council"])
         return council.get("registration_contacts", self.get_electoral_services())
 
-    def make_wcivf_by_ballot(self):
+    def make_wcivf_ballots(self):
         """
         Iterate over the WCIVF response once to create a dict keyed by
         ballot paper ID
@@ -199,7 +199,7 @@ class Stitcher:
 
         for date in results:
             for ballot in date["ballots"]:
-                wcivf_ballot = self.wcivf_by_ballot[ballot["ballot_paper_id"]]
+                wcivf_ballot = self.wcivf_ballots[ballot["ballot_paper_id"]]
 
                 ballot["ballot_url"] = self.request.build_absolute_uri(
                     reverse("api:v1:elections_get", args=(ballot["ballot_paper_id"],))

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -1,3 +1,4 @@
+import re
 from copy import deepcopy
 from django.urls import reverse
 
@@ -8,10 +9,10 @@ def ballot_charisma(ballot, sort_keys):
         "parl": {"default": 90},
         "europarl": {"default": 80},
         "mayor": {"default": 70, "local-authority": 65},
-        "naw": {"default": 60},
-        "sp": {"default": 60},
         "nia": {"default": 60},
-        "gla": {"default": 60},
+        "gla": {"default": 60, "a": 55},
+        "naw": {"default": 60, "r": 55},
+        "sp": {"default": 60, "r": 55},
         "pcc": {"default": 50},
         "local": {"default": 40},
     }
@@ -27,9 +28,11 @@ def ballot_charisma(ballot, sort_keys):
     default_weight_for_election_type = weights.get("default")
     base_charisma = weights.get(organisation_type, default_weight_for_election_type)
 
-    # GLA Additional are less important than constituencies
-    if ballot_paper_id.startswith("gla.a"):
-        modifier += 1
+    # Look up `r` and `a` subtypes
+    subtype = re.match(r"^[^.]+\.([ar])\.", ballot_paper_id)
+    if subtype:
+        base_charisma = weights.get(subtype.group(1), base_charisma)
+
     # by-elections are slightly less charismatic than scheduled elections
     if ".by." in ballot_paper_id:
         modifier += 1

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -17,10 +17,16 @@ def ballot_charisma(ballot, sort_keys):
     }
     modifier = 0
     ballot_paper_id = ballot["ballot_paper_id"]
-    values_for_type = charisma_map[ballot_paper_id.split(".")[0]]
-    base_charisma = values_for_type.get(
-        sort_keys.get(ballot_paper_id), values_for_type.get("default")
-    )
+
+    # Look up the dict of possible weights for this election type
+    weights = charisma_map[ballot_paper_id.split(".")[0]]
+
+    # Extract the organisation type from the sort keys
+    organisation_type = sort_keys.get(ballot_paper_id)
+
+    default_weight_for_election_type = weights.get("default")
+    base_charisma = weights.get(organisation_type, default_weight_for_election_type)
+
     # GLA Additional are less important than constituencies
     if ballot_paper_id.startswith("gla.a"):
         modifier += 1

--- a/aggregator/apps/api/v1/tests/test_sort_ballots.py
+++ b/aggregator/apps/api/v1/tests/test_sort_ballots.py
@@ -5,15 +5,41 @@ from api.v1.stitcher import sort_ballots
 class SortBallotsTests(TestCase):
     def test_sorter(self):
         initial = [
-            {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
-            {"ballot_paper_id": "mayor.greater-manchester-ca.2020-05-07"},
-            {"ballot_paper_id": "parl.manchester-central.2019-12-12"},
-            {"ballot_paper_id": "parl.manchester-central.by.2019-12-12"},
+            {
+                "poll_open_date": "2020-02-27",
+                "ballots": [
+                    {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
+                    {"ballot_paper_id": "mayor.greater-manchester-ca.2020-02-27"},
+                    {"ballot_paper_id": "parl.manchester-central.2020-02-27"},
+                    {"ballot_paper_id": "parl.manchester-central.by.2020-02-27"},
+                ],
+            },
+            {
+                "poll_open_date": "2020-05-07",
+                "ballots": [
+                    {"ballot_paper_id": "gla.a.2020-05-07"},
+                    {"ballot_paper_id": "gla.c.lambeth-and-southwark.2020-05-07"},
+                    {"ballot_paper_id": "mayor.london.2020-05-07"},
+                ],
+            },
         ]
         expected = [
-            {"ballot_paper_id": "parl.manchester-central.2019-12-12"},
-            {"ballot_paper_id": "parl.manchester-central.by.2019-12-12"},
-            {"ballot_paper_id": "mayor.greater-manchester-ca.2020-05-07"},
-            {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
+            {
+                "poll_open_date": "2020-02-27",
+                "ballots": [
+                    {"ballot_paper_id": "parl.manchester-central.2020-02-27"},
+                    {"ballot_paper_id": "parl.manchester-central.by.2020-02-27"},
+                    {"ballot_paper_id": "mayor.greater-manchester-ca.2020-02-27"},
+                    {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
+                ],
+            },
+            {
+                "poll_open_date": "2020-05-07",
+                "ballots": [
+                    {"ballot_paper_id": "mayor.london.2020-05-07"},
+                    {"ballot_paper_id": "gla.c.lambeth-and-southwark.2020-05-07"},
+                    {"ballot_paper_id": "gla.a.2020-05-07"},
+                ],
+            },
         ]
         self.assertEqual(expected, sort_ballots(initial))

--- a/aggregator/apps/api/v1/tests/test_sort_ballots.py
+++ b/aggregator/apps/api/v1/tests/test_sort_ballots.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+from api.v1.stitcher import sort_ballots
+
+
+class SortBallotsTests(TestCase):
+    def test_sorter(self):
+        initial = [
+            {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
+            {"ballot_paper_id": "mayor.greater-manchester-ca.2020-05-07"},
+            {"ballot_paper_id": "parl.manchester-central.2019-12-12"},
+            {"ballot_paper_id": "parl.manchester-central.by.2019-12-12"},
+        ]
+        expected = [
+            {"ballot_paper_id": "parl.manchester-central.2019-12-12"},
+            {"ballot_paper_id": "parl.manchester-central.by.2019-12-12"},
+            {"ballot_paper_id": "mayor.greater-manchester-ca.2020-05-07"},
+            {"ballot_paper_id": "local.manchester.clayton-openshaw.2020-02-27"},
+        ]
+        self.assertEqual(expected, sort_ballots(initial))

--- a/aggregator/apps/api/v1/tests/test_sort_ballots.py
+++ b/aggregator/apps/api/v1/tests/test_sort_ballots.py
@@ -42,4 +42,29 @@ class SortBallotsTests(TestCase):
                 ],
             },
         ]
-        self.assertEqual(expected, sort_ballots(initial))
+        self.assertEqual(expected, sort_ballots(initial, {}))
+
+    def test_mayor_types_sorted(self):
+        initial = [
+            {
+                "poll_open_date": "2020-05-07",
+                "ballots": [
+                    {"ballot_paper_id": "mayor.liverpool.2020-05-07"},
+                    {"ballot_paper_id": "mayor.liverpool-city-ca.2020-05-07"},
+                ],
+            }
+        ]
+        sort_keys = {
+            "mayor.liverpool.2020-05-07": "local-authority",
+            "mayor.liverpool-city-ca.2020-05-07": "combined-authority",
+        }
+        expected = [
+            {
+                "poll_open_date": "2020-05-07",
+                "ballots": [
+                    {"ballot_paper_id": "mayor.liverpool-city-ca.2020-05-07"},
+                    {"ballot_paper_id": "mayor.liverpool.2020-05-07"},
+                ],
+            }
+        ]
+        self.assertEqual(expected, sort_ballots(initial, sort_keys))


### PR DESCRIPTION
Replaces https://github.com/DemocracyClub/aggregator-api/pull/124 by adding organisation type to the sort ordering.

I've done a few other bits of refactoring here to make accessing the data I need easier. The main change is to sort the _final_ dicts rather than the "minimal" ones. This is useful for our current use case of sorting by a single other key, but you can imagine wanting to sort by some other aspect of the final dict in future, so I think this make some sense.

I also jumped through some hoops passing the sort function some data that's not in the dict we want – storing `ballot_sort_keys` on the class feels a bit like a hack, but I'm not sure how else to do this.