### PR TITLE
Don't fail if ballot list mismatches between WDIV and WCIVF

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -24,6 +24,7 @@ django-cors-headers = ">=2.0.0,<3.3.0"
 aws-wsgi = {ref = "unquote_path_strings", git = "https://github.com/DemocracyClub/awsgi.git"}
 dc-base-theme = { ref = "0.3.12", git = "https://github.com/DemocracyClub/dc_base_theme.git" }
 whitenoise = "*"
+sentry-sdk = "*"
 
 [scripts]
 black = "black ."

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c3a014094be6c85ec111fa411950cc0fd83e4352254a683a69c921443ad5c57f"
+            "sha256": "2f1cf8df9173774afa2cb075347e2cd8d881f252343a4480aad582753df36efc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -78,6 +78,13 @@
         "aws-wsgi": {
             "git": "https://github.com/DemocracyClub/awsgi.git",
             "ref": "a5b800373c326e75f705d400c48f7df301409724"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:1a4995114262bffbc2413b159f2a1a480c969de6e6eb13ee966d470af86af59c",
+                "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"
+            ],
+            "version": "==2020.12.5"
         },
         "cffi": {
             "hashes": [
@@ -294,6 +301,14 @@
             ],
             "version": "==0.4.0"
         },
+        "sentry-sdk": {
+            "hashes": [
+                "sha256:71de00c9711926816f750bc0f57ef2abbcb1bfbdf5378c601df7ec978f44857a",
+                "sha256:9221e985f425913204989d0e0e1cbb719e8b7fa10540f1bc509f660c06a34e66"
+            ],
+            "index": "pypi",
+            "version": "==1.0.0"
+        },
         "six": {
             "hashes": [
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
@@ -310,6 +325,14 @@
             ],
             "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "version": "==1.26.4"
         },
         "whitenoise": {
             "hashes": [
@@ -398,19 +421,19 @@
         },
         "aws-sam-cli": {
             "hashes": [
-                "sha256:3789e961b90e50619399e0d1e58c7467c10290e5b9922a119400985d4fe00367",
-                "sha256:f7e41a7cb920d435f8cade26498ddce36ea694b01bef2057228da001477f6e4b"
+                "sha256:b5d5f728dc324ab8c2a34903538f1af034dfa90985640077ae30a70cedd5e6de",
+                "sha256:b6c161901dca7f83eadbb6f50bf6c098a3699994c97df414797398f4b2a515b5"
             ],
             "index": "pypi",
-            "version": "==1.20.0"
+            "version": "==1.21.1"
         },
         "aws-sam-translator": {
             "hashes": [
-                "sha256:1cfc8ba13c43e8c425fdcd6c246fdd90899a3ed89310d84a72ccdf082e4146d7",
-                "sha256:857c62a03e3bb4a3f7074e867f52ced636dc06192c8216e00732122f21a206c2",
-                "sha256:a22d505ddc0c48e3cf0ff0127096bdc1231d20c852509201ffba47dc8e683a1a"
+                "sha256:2f8904fd4a631752bc441a8fd928c444ed98ceb86b94d25ed7b84982e2eff1cd",
+                "sha256:5cf7faab3566843f3b44ef1a42a9c106ffb50809da4002faab818076dcc7bff8",
+                "sha256:c35075e7e804490d6025598ed4878ad3ab8668e37cafb7ae75120b1c37a6d212"
             ],
-            "version": "==1.34.0"
+            "version": "==1.35.0"
         },
         "binaryornot": {
             "hashes": [
@@ -429,19 +452,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:273e96ae2b95a6036a4c3547e76a270b17ab761cc76053823c9e361d268213ef",
-                "sha256:399ccbd31b7aa09d53c4e449fe575803b033fcc23ed3a1d7ae2fe7a04727a562"
+                "sha256:6ec718f5a75724f6117a47944a3b2dd79aef02ed75b356060cede74fb91e2616",
+                "sha256:b5814ff73b5b8fc8601c1b73b70675807f9ce64713562e183a08415a2516eed4"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.17.25"
+            "version": "==1.17.39"
         },
         "botocore": {
             "hashes": [
-                "sha256:b80b4efe5fafb29f24a3657d1f77aa170525c876b5fd9384d5e5859d0405206e",
-                "sha256:f1c04a5e96944b628ae98a2975829125c0e9b99f9be7b118d42fb82cef3c420a"
+                "sha256:28506d23ffa9abf5666c2c909c7edc83a1112cd44fe74eb1a4960df561531e98",
+                "sha256:54587d3c9d0d98ac579681245ea36f547cd5048e2bb9212e5e7166a963bcb562"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.25"
+            "version": "==1.20.39"
         },
         "certifi": {
             "hashes": [
@@ -587,11 +610,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:18d5ff601069f98d5d605b6a4b50c18a34811d655c55548adc833e687289acde",
-                "sha256:407d13f55dc6f2a844e62325d18ad7019a436c4bfcaee34cda35f2be6e7c3e34"
+                "sha256:1cedf994a9b6885dcbb7ed40b24c332b1de3956319f4b1a0f07c0621d453accc",
+                "sha256:c9c1b6c7dbc62084f3e6a614a194eb16ded7947736c18e3300125d5c0a7a8b3c"
             ],
             "index": "pypi",
-            "version": "==3.7.2"
+            "version": "==3.9.1"
         },
         "iniconfig": {
             "hashes": [
@@ -736,11 +759,11 @@
         },
         "pyflakes": {
             "hashes": [
-                "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92",
-                "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"
+                "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3",
+                "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.2.0"
+            "version": "==2.3.1"
         },
         "pyparsing": {
             "hashes": [
@@ -847,49 +870,49 @@
         },
         "regex": {
             "hashes": [
-                "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538",
-                "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4",
-                "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc",
-                "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa",
-                "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444",
-                "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1",
-                "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af",
-                "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8",
-                "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9",
-                "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88",
-                "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba",
-                "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364",
-                "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e",
-                "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7",
-                "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0",
-                "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31",
-                "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683",
-                "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee",
-                "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b",
-                "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884",
-                "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c",
-                "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e",
-                "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562",
-                "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85",
-                "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c",
-                "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6",
-                "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d",
-                "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b",
-                "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70",
-                "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b",
-                "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b",
-                "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f",
-                "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0",
-                "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5",
-                "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5",
-                "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f",
-                "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e",
-                "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512",
-                "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d",
-                "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917",
-                "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"
+                "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139",
+                "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5",
+                "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa",
+                "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3",
+                "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df",
+                "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f",
+                "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e",
+                "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd",
+                "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d",
+                "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e",
+                "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f",
+                "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa",
+                "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68",
+                "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643",
+                "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3",
+                "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be",
+                "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578",
+                "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c",
+                "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5",
+                "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba",
+                "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe",
+                "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c",
+                "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a",
+                "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb",
+                "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d",
+                "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38",
+                "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18",
+                "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce",
+                "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa",
+                "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6",
+                "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5",
+                "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90",
+                "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c",
+                "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106",
+                "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7",
+                "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0",
+                "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689",
+                "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd",
+                "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932",
+                "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf",
+                "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"
             ],
-            "version": "==2020.11.13"
+            "version": "==2021.3.17"
         },
         "requests": {
             "hashes": [
@@ -902,10 +925,10 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:1e28620e5b444652ed752cf87c7e0cb15b0e578972568c6609f0f18212f259ed",
-                "sha256:7fdddb4f22275cf1d32129e21f056337fd2a80b6ccef1664528145b72c49e6d2"
+                "sha256:5d48b1fd2232141a9d5fb279709117aaba506cacea7f86f11bc392f06bfa8fc2",
+                "sha256:c5dadf598762899d8cfaecf68eba649cd25b0ce93b6c954b156aaa3eed160547"
             ],
-            "version": "==0.3.4"
+            "version": "==0.3.6"
         },
         "serverlessrepo": {
             "hashes": [
@@ -964,11 +987,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2",
-                "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"
+                "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
+                "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.25.11"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
+            "version": "==1.26.4"
         },
         "watchdog": {
             "hashes": [

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -50,10 +50,6 @@ def sort_ballots(dates, sort_keys):
     return dates
 
 
-class StitcherValidationError(Exception):
-    pass
-
-
 class NotificationsMaker:
     def __init__(self, ballots):
         self.ballots = ballots

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -106,6 +106,7 @@ class Stitcher:
                 message = f'Could not find expected ballot {ballot["ballot_paper_id"]}'
                 # Log the mismatched ballots to sentry, but don't raise an error
                 capture_message(message)
+                return False
 
         # TODO: define a schema and validate against it here to ensure
         # the wdiv/wcivf responses we've got to work with make sense

--- a/aggregator/apps/api/v1/tests/test_stitcher.py
+++ b/aggregator/apps/api/v1/tests/test_stitcher.py
@@ -67,3 +67,15 @@ class StitcherTests(TestCase):
         self.assertDictEqual(
             s.make_result_known_response(), load_sandbox_output(postcode)
         )
+
+    def test_validate_false_with_mismatched_balots(self):
+        postcode = "AA14AA"
+        wcivf = load_fixture(fixture_map[postcode], "wcivf")
+        s = Stitcher(load_fixture(fixture_map[postcode], "wdiv"), wcivf, self.request)
+        self.assertTrue(s.validate())
+
+        # Remove an election from WCIVF
+        wcivf.pop(0)
+
+        s = Stitcher(load_fixture(fixture_map[postcode], "wdiv"), wcivf, self.request)
+        self.assertFalse(s.validate())

--- a/aggregator/apps/api/v1/tests/views/test_address_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_address_view.py
@@ -17,22 +17,6 @@ def stitcher_error(*args, **kwargs):
 class AddressViewTests(TestCase):
     maxDiff = None
 
-    @patch(
-        "api.v1.api_client.proxy_single_request",
-        partial(
-            mock_proxy_single_request, "addresspc_endpoints/test_multiple_elections"
-        ),
-    )
-    @patch("api.v1.stitcher.Stitcher.validate", stitcher_error)
-    def test_stitcher_error(self):
-        # we're mocking a valid set of WDIV/WCIVF responses here
-        # but when we try to parse them, Stitcher will throw an error
-        response = self.client.get(
-            "/api/v1/address/1-foo-street-bar-town/", HTTP_AUTHORIZATION="Token foo"
-        )
-        self.assertEqual(500, response.status_code)
-        self.assertDictEqual({"message": "Internal Server Error"}, response.json())
-
     def test_valid(self):
         # iterate through the subset of applicable expected inputs/outputs
         # we test against in test_stitcher.py

--- a/aggregator/apps/api/v1/tests/views/test_address_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_address_view.py
@@ -10,12 +10,24 @@ from api.v1.tests.helpers import (
 )
 
 
-def stitcher_error(*args, **kwargs):
-    raise StitcherValidationError("foo")
-
-
 class AddressViewTests(TestCase):
     maxDiff = None
+
+    @patch(
+        "api.v1.api_client.proxy_single_request",
+        partial(
+            mock_proxy_single_request, "addresspc_endpoints/test_multiple_elections"
+        ),
+    )
+    def test_no_stitcher_error_with_mismatched_ballots(self):
+        """
+        Dispite the ballots mismatching, don't raise an error
+
+        """
+        response = self.client.get(
+            "/api/v1/address/1-foo-street-bar-town/", HTTP_AUTHORIZATION="Token foo"
+        )
+        self.assertEqual(200, response.status_code)
 
     def test_valid(self):
         # iterate through the subset of applicable expected inputs/outputs

--- a/aggregator/apps/api/v1/tests/views/test_address_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_address_view.py
@@ -1,7 +1,6 @@
 from functools import partial
 from unittest.mock import Mock, patch
 from django.test import TestCase
-from api.v1.stitcher import StitcherValidationError
 from api.v1.tests.helpers import (
     fixture_map,
     load_fixture,

--- a/aggregator/apps/api/v1/tests/views/test_postcode_view.py
+++ b/aggregator/apps/api/v1/tests/views/test_postcode_view.py
@@ -1,17 +1,12 @@
 from functools import partial
 from unittest.mock import Mock, patch
 from django.test import TestCase
-from api.v1.stitcher import StitcherValidationError
 from api.v1.tests.helpers import (
     fixture_map,
     load_fixture,
     load_sandbox_output,
     mock_proxy_multiple_requests,
 )
-
-
-def stitcher_error(*args, **kwargs):
-    raise StitcherValidationError("foo")
 
 
 class PostcodeViewTests(TestCase):

--- a/aggregator/apps/api/v1/views.py
+++ b/aggregator/apps/api/v1/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponse, JsonResponse
 from django.views import View
 from ..errors import ApiError
 from .api_client import EEApiClient, WdivWcivfApiClient, UpstreamApiError
-from .stitcher import Stitcher, StitcherValidationError
+from .stitcher import Stitcher
 
 
 class BaseView(View, metaclass=abc.ABCMeta):
@@ -37,10 +37,7 @@ class PostcodeView(BaseView):
         client = WdivWcivfApiClient(request)
         wdiv, wcivf = client.get_data_for_postcode(kwargs["postcode"])
 
-        try:
-            stitcher = Stitcher(wdiv, wcivf, request)
-        except StitcherValidationError:
-            raise ApiError("Internal Server Error")
+        stitcher = Stitcher(wdiv, wcivf, request)
 
         if not wdiv["polling_station_known"] and len(wdiv["addresses"]) > 0:
             result = stitcher.make_address_picker_response()
@@ -55,10 +52,7 @@ class AddressView(BaseView):
         client = WdivWcivfApiClient(request)
         wdiv, wcivf = client.get_data_for_address(kwargs["slug"])
 
-        try:
-            stitcher = Stitcher(wdiv, wcivf, request)
-        except StitcherValidationError:
-            raise ApiError("Internal Server Error")
+        stitcher = Stitcher(wdiv, wcivf, request)
 
         result = stitcher.make_result_known_response()
 

--- a/aggregator/settings/base.py
+++ b/aggregator/settings/base.py
@@ -130,10 +130,15 @@ from .constants import *  # noqa
 
 sentry_dsn = os.environ.get("SENTRY_DSN", None)
 if sentry_dsn:
-    import raven  # noqa
+    import sentry_sdk
+    from sentry_sdk.integrations.django import DjangoIntegration
 
-    RAVEN_CONFIG = {"dsn": sentry_dsn, "environment": os.environ.get("ENV", None)}
-    INSTALLED_APPS.append("raven.contrib.django.raven_compat")
+    sentry_sdk.init(
+        dsn="https://examplePublicKey@o0.ingest.sentry.io/0",
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=1.0,
+        send_default_pii=False,
+    )
 
     LOGGING = {
         "version": 1,
@@ -141,25 +146,9 @@ if sentry_dsn:
         "filters": {
             "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}
         },
-        "handlers": {
-            "sentry": {
-                "level": "ERROR",
-                "class": "raven.contrib.django.raven_compat.handlers.SentryHandler",
-            },
-            "null": {"class": "logging.NullHandler"},
-        },
         "loggers": {
             # Silence DisallowedHost exception by setting null error handler
-            "django.security.DisallowedHost": {
-                "handlers": ["null"],
-                "propagate": False,
-            },
-            # Send middleware errors to sentry
-            "api.middleware": {
-                "level": "ERROR",
-                "handlers": ["sentry"],
-                "propagate": False,
-            },
+            "django.security.DisallowedHost": {"handlers": ["null"], "propagate": False}
         },
     }
 


### PR DESCRIPTION
With a combination of more baseline traffic and more...uncertain...elections, we're getting a lot more [`Could not find expected ballot`](https://sentry.io/organizations/democracy-club-gp/issues/2250199742/?project=1405979&query=is%3Aunresolved) errors in production.

Most of the time this is short lived, as WDIV and WCIVF sync at slightly different times, and for most of our users outside of election week they are just after contact details, not lists of ballots.

Because of that, this removes the validation error if the ballots list don't match, and just removes the missing ballot fro the response completely.

I'm not 100% convinced this is the right approach - feedback very welcome.  