### PR TITLE
Use existing metadata key for cancellation reason

### DIFF
--- a/aggregator/apps/api/v1/sandbox-responses/AA12AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA12AA.json
@@ -58,7 +58,6 @@
           "elected_role": "Local Councillor",
           "metadata": null,
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": null,
           "election_id": "local.westminster.2018-11-22",

--- a/aggregator/apps/api/v1/sandbox-responses/AA12AB.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA12AB.json
@@ -21,7 +21,6 @@
           "elected_role": "Local Councillor",
           "metadata": null,
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": null,
           "election_id": "local.westminster.2018-11-22",

--- a/aggregator/apps/api/v1/sandbox-responses/AA14AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA14AA.json
@@ -21,7 +21,6 @@
           "elected_role": "Mayor of Lewisham",
           "metadata": null,
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": null,
           "election_id": "mayor.lewisham.2018-05-03",
@@ -174,7 +173,6 @@
               }
           },
           "cancelled": true,
-          "cancellation_reason": null,
           "voting_system": {
             "slug": "FPTP",
             "name": "First-past-the-post",
@@ -389,7 +387,6 @@
           "elected_role": "Local Councillor",
           "metadata": null,
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": "local.lewisham.blackheath.2018-05-03",
           "seats_contested": 1,
@@ -604,7 +601,6 @@
           "elected_role": "Member of Parliament",
           "metadata": null,
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": null,
           "election_id": "parl.2018-06-14",

--- a/aggregator/apps/api/v1/sandbox-responses/AA15AA.json
+++ b/aggregator/apps/api/v1/sandbox-responses/AA15AA.json
@@ -34,7 +34,6 @@
             }
           },
           "cancelled": false,
-          "cancellation_reason": null,
           "replaced_by": null,
           "replaces": null,
           "election_id": "parl.2018-05-03",

--- a/aggregator/apps/api/v1/stitcher.py
+++ b/aggregator/apps/api/v1/stitcher.py
@@ -106,10 +106,10 @@ class NotificationsMaker:
         """
         cancelled_ballot_details = []
         for ballot in self.cancelled_ballots:
-            reason_metadata = get_ballot_cancellation_reason_metadata(ballot)
+            reason_metadata = get_ballot_cancellation_reason_metadata(ballot) or {}
             cancelled_ballot = {
                 "ballot_paper_id": ballot["ballot_paper_id"],
-                "detail": reason_metadata["detail"] or None,
+                "detail": reason_metadata.get("detail"),
             }
             cancelled_ballot_details.append(cancelled_ballot)
 

--- a/aggregator/apps/api/v1/tests/test_notifications.py
+++ b/aggregator/apps/api/v1/tests/test_notifications.py
@@ -1,5 +1,5 @@
 import pytest
-from api.v1.stitcher import NotificationsMaker, get_ballot_cancellation_reason
+from api.v1.stitcher import NotificationsMaker, get_ballot_cancellation_reason_metadata
 
 nometa = {
     "ballot_paper_id": "local.nometa.2018-05-03",
@@ -189,8 +189,9 @@ def test_northern_ireland():
     ],
 )
 def test_get_ballot_cancellation_reason(ballot, expected_reason):
-    reason = get_ballot_cancellation_reason(ballot)
-    assert reason == expected_reason
+    reason = get_ballot_cancellation_reason_metadata(ballot)
+    assert reason["title"] == "Uncontested election"
+    assert reason["detail"] == expected_reason
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
@Bekabyx, this is 100% my fault and I only noticed when implementing the changes on another project. Lesson: it's good to dog food your APIs :sunglasses: 

Rather than adding a new key, we can just use the existing metadata key. This change implements this, and ensures we don't squash any existing metadata that we might have added in EE. It will squash _other_ metadata if we have a cancellation reason.

See the commit message for more.

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Tests have been added and/or updated
- [x] Did I use the clear and concise names for variables and functions?
- [x] Did I explain all possible solutions and why I chose the one I did?
- [x] Added any comments to make new functions clearer
- [x] Have I rebased with the latest version of master?
```
