### PR TITLE
Remove recall petition

### DIFF
--- a/api/common/settings.py
+++ b/api/common/settings.py
@@ -9,8 +9,6 @@ WCIVF_BALLOT_CACHE_URL = (
     "https://wcivf-ballot-cache.s3.eu-west-2.amazonaws.com/ballot_data/"
 )
 EE_BASE_URL = "https://elections.democracyclub.org.uk/api/"
-RECALL_PETITION_BASE_URL = (
-    "https://klbyvve95g.execute-api.eu-west-2.amazonaws.com/prod/"
-)
+RECALL_PETITION_ENABLED = False
 
 DEBUG = bool(int(os.environ.get("DEBUG", "0")))

--- a/api/endpoints/v1/voting_information/stitcher.py
+++ b/api/endpoints/v1/voting_information/stitcher.py
@@ -2,6 +2,7 @@ import re
 from copy import deepcopy
 from typing import Dict, List, Optional
 
+from common import settings
 from common.url_resolver import build_absolute_url
 from recall_petitions.client import RecallPetitionApiClient
 from starlette.requests import Request
@@ -398,9 +399,11 @@ class Stitcher:
         }
 
         # TODO: Remove when we remove petitions
-        if hasattr(
-            self.request, "query_params"
-        ) and self.request.query_params.get("recall_petition"):
+        if (
+            settings.RECALL_PETITION_ENABLED
+            and hasattr(self.request, "query_params")
+            and self.request.query_params.get("recall_petition")
+        ):
             resp["parl_recall_petition"] = None
             recall_petition_councils = ["SLK"]
             council_id = resp["electoral_services"]["council_id"]


### PR DESCRIPTION
Removed using a feature flag rather than deleting the code.

I did this for two reasons:

1. We might have more of these, and the code isn't taking up so much space that we can't just keep it here.
2. We might do something like this (reading from S3 Select) for other things in future and it's useful to have a pattern for it in the codebase.
