### PR TITLE
Feature/cancellation reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ This project provides an API gateway in front of other Democracy Club APIs.
 ### Application
 
 * `cp aggregator-api/aggregator/settings/local.example.py aggregator-api/aggregator/settings/local.py`
-* Install Python dependencies: `pipenv install --dev`
+* Install Python dependencies
+  * This project makes use of the new pipenv categories. This means a straight `pipenv install` no longer works, and instead we must install by category. `pipenv install --categories "frontend api dev-packages"` will get you everything.
+  * When installing a new dependency, you must define the category you're installing it into, e.g. `pipenv install --categories "frontend" django`
+  * When removing a dependency you must remove it from the category it's defined in, e.g. `pipenv uninstall --categories "frontend" django `
+
 * Run the test suite: `pytest`
 * Run lint checks: `pytest --ruff`
 * Auto-format: `black .`

--- a/api/endpoints/v1/sandbox/sandbox-responses/AA14AA.json
+++ b/api/endpoints/v1/sandbox/sandbox-responses/AA14AA.json
@@ -165,14 +165,9 @@
           "ballot_url": "https://developers.democracyclub.org.uk/api/v1/sandbox/elections/local.lewisham.blackheath.2018-05-03/",
           "poll_open_date": "2018-05-03",
           "elected_role": "Local Councillor",
-          "metadata": {
-            "cancelled_election": {
-                "title": "Cancelled Election",
-                "url": "https://www.lewisham.gov.uk/mayorandcouncil/elections/Pages/default.aspx",
-                "detail": "The election for a Borough Councillor to represent the Blackheath Ward has now been postponed due to leaves on the line."
-              }
-          },
+          "metadata": null,
           "cancelled": true,
+          "cancellation_reason": "UNDER_CONTESTED",
           "voting_system": {
             "slug": "FPTP",
             "name": "First-past-the-post",

--- a/api/endpoints/v1/voting_information/elections_api_client.py
+++ b/api/endpoints/v1/voting_information/elections_api_client.py
@@ -42,7 +42,6 @@ class WdivWcivfApiClient:
         return QueryParams(utm_medium=settings.USER_AGENT)
 
     def get_wdiv_json(self, url):
-        print(url)
         resp = app_httpx_client.get(url, params=self.wdiv_params)
         if resp.status_code >= 400:
             raise UpstreamApiError(resp)
@@ -58,7 +57,6 @@ class WdivWcivfApiClient:
                 resp = app_httpx_client.get(
                     wcivf_ballot_cache_url_from_ballot(ballot)
                 )
-                print(resp.status_code)
                 if resp.status_code >= 400 and not resp.status_code == 403:
                     raise UpstreamApiError(resp)
                 resp.raise_for_status()

--- a/api/tests/v1/test_data/addresspc_endpoints/test_multiple_elections/wdiv.json
+++ b/api/tests/v1/test_data/addresspc_endpoints/test_multiple_elections/wdiv.json
@@ -44,14 +44,9 @@
       "ballot_title": "Lewisham local election Blackheath",
       "poll_open_date": "2018-05-03",
       "elected_role": "Local Councillor",
-      "metadata": {
-        "cancelled_election": {
-            "title": "Cancelled Election",
-            "url": "https://www.lewisham.gov.uk/mayorandcouncil/elections/Pages/default.aspx",
-            "detail": "The election for a Borough Councillor to represent the Blackheath Ward has now been postponed due to leaves on the line."
-          }
-      },
+      "metadata": null,
       "cancelled": true,
+      "cancellation_reason": "UNDER_CONTESTED",
       "replaced_by": "local.lewisham.blackheath.2018-05-10",
       "replaces": null
     },

--- a/api/tests/v1/voting_information/test_stitcher.py
+++ b/api/tests/v1/voting_information/test_stitcher.py
@@ -2,7 +2,11 @@ import pytest
 from starlette.testclient import TestClient
 from tests.helpers import fixture_map, load_fixture, load_sandbox_output
 from voting_information.app import app
-from voting_information.stitcher import Stitcher
+from voting_information.stitcher import (
+    CANCELLATION_REASONS,
+    Stitcher,
+    get_ballot_cancellation_reason_data,
+)
 
 
 @pytest.fixture(scope="function")
@@ -111,3 +115,18 @@ def test_validate_false_with_mismatched_ballots(stitcher_client):
         load_fixture(fixture_map[postcode], "wdiv"), wcivf_json, stitcher_client
     )
     assert s.validate() is False
+
+
+@pytest.mark.parametrize(
+    "cancelled, reason_code, reason_dict",
+    [
+        (True, None, {}),
+        (True, "CANDIDATE_DEATH", CANCELLATION_REASONS["CANDIDATE_DEATH"]),
+        (False, None, None),
+    ],
+)
+def test_get_ballot_cancellation_reason_data(
+    cancelled, reason_code, reason_dict
+):
+    ballot = {"cancelled": cancelled, "cancellation_reason": reason_code}
+    assert get_ballot_cancellation_reason_data(ballot) == reason_dict

--- a/frontend/apps/api_docs/v1/docs/finder_data_structures.apibp
+++ b/frontend/apps/api_docs/v1/docs/finder_data_structures.apibp
@@ -27,6 +27,13 @@
 + geometry (Point)
 
 
+## CancellationReason (enum)
++ `NO_CANDIDATES`
++ `EQUAL_CANDIDATES`
++ `UNDER_CONTESTED`
++ `CANDIDATE_DEATH`
+
+
 ## ValidFinderResponse (object)
 + `address_picker`: `false` (boolean) - True if we need to show this user an address picker
 + addresses (array[object]) - An array of address objects containing the addresses applicable to this request (if necessary)
@@ -79,6 +86,7 @@
                 + `elected_role`: `Local Councillor` (string) - Name of the role the winner(s) of this election will assume
                 + metadata: (object, nullable) - Object containing information about special conditions for the user to be aware about (e.g: cancelled elections, voter id pilot). (details TBC)
                 + cancelled: `false` (boolean) - True if this ballot has been cancelled
+                + cancellation_reason: `null` (CancellationReason, nullable) - If a ballot has been cancelled, this key may hold a codified reason for that ballot's cancellation
                 + `replaced_by`: (string, nullable) - If a ballot has been cancelled (cancelled = true) and rescheduled for a later date, this key will hold the ballot_paper_id of the ballot that replaces it.
                 + replaces: (string, nullable) - If this ballot replaces another cancelled ballot, this key will hold the ballot_paper_id of the ballot that it replaces.
                 + `election_id`: `local.cardiff.2017-05-04` (string) - Identifier for this ballot's parent election group

--- a/frontend/apps/api_docs/v1/docs/notes.apibp
+++ b/frontend/apps/api_docs/v1/docs/notes.apibp
@@ -76,7 +76,7 @@ Sometimes a scheduled poll may be cancelled. This is usually either because
 the election is uncontested or due to death of a candidate.
 
 If the user has more than one ballot and only one of them is cancelled, we will not add a notification. In this case,
-you should look at the `cancelled` value on each ballot.
+you should look at the `cancelled` and `cancellation_reason` values on each ballot.
 
 If every ballot for a date is cancelled (meaning the user has no election to vote in) then we will add a notification
 alerting them that they don't have to vote on that day, e.g:
@@ -95,30 +95,14 @@ alerting them that they don't have to vote on that day, e.g:
 </code></pre>
 
 
-In some cases we will know the reason for the cancellation(s). In this case we will add a key to the notification:
+When we know the reason for a cancelled ballot we will add a `cancellation_reason` to the ballot object, next to the
+`cancelled` boolean:
 
-<pre><code>{
-...
-  "notifications": [
-    {
-       "type": "cancelled_election",
-       "title": "Cancelled Election",
-       "url": null,
-       "detail": "The poll for this election will not take place",
-       "cancelled_ballots": [
-           {
-               "ballot_paper_id": "local.foo.2023-02-24",
-               "detail": "Uncontested election with fewer candidates than seats"
-           },
-           {
-               "ballot_paper_id": "pcc.foo.2023-02-24",
-               "detail": "Uncontested election with equal candidates to seats"
-           }
-       ]
-   }
-  ]
-}
-</code></pre>
+* `NO_CANDIDATES`: No candidates
+* `EQUAL_CANDIDATES`: Equal candidates to contested seats
+* `UNDER_CONTESTED`: Fewer candidates than seats
+* `CANDIDATE_DEATH`: Death of a candidate
+
 
 
 ### Advance Voting Stations

--- a/frontend/apps/api_docs/v1/templates/api_docs_rendered.html
+++ b/frontend/apps/api_docs/v1/templates/api_docs_rendered.html
@@ -338,6 +338,7 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
           &quot;elected_role&quot;: &quot;Local Councillor&quot;,
           &quot;metadata&quot;: null,
           &quot;cancelled&quot;: false,
+          &quot;cancellation_reason&quot;: &quot;null&quot;,
           &quot;replaced_by&quot;: null,
           &quot;replaces&quot;: null,
           &quot;election_id&quot;: &quot;local.cardiff.2017-05-04&quot;,
@@ -651,6 +652,21 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
                 &quot;cancelled&quot;: {
                   &quot;type&quot;: &quot;boolean&quot;,
                   &quot;description&quot;: &quot;True if this ballot has been cancelled&quot;
+                },
+                &quot;cancellation_reason&quot;: {
+                  &quot;type&quot;: [
+                    &quot;string&quot;,
+                    &quot;null&quot;
+                  ],
+                  &quot;enum&quot;: [
+                    &quot;NO_CANDIDATES&quot;,
+                    &quot;EQUAL_CANDIDATES&quot;,
+                    &quot;UNDER_CONTESTED&quot;,
+                    &quot;CANDIDATE_DEATH&quot;,
+                    &quot;null&quot;,
+                    null
+                  ],
+                  &quot;description&quot;: &quot;If a ballot has been cancelled, this key may hold a codified reason for that ballot&#x27;s cancellation&quot;
                 },
                 &quot;replaced_by&quot;: {
                   &quot;type&quot;: [
@@ -1333,6 +1349,7 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
           &quot;elected_role&quot;: &quot;Local Councillor&quot;,
           &quot;metadata&quot;: null,
           &quot;cancelled&quot;: false,
+          &quot;cancellation_reason&quot;: &quot;null&quot;,
           &quot;replaced_by&quot;: null,
           &quot;replaces&quot;: null,
           &quot;election_id&quot;: &quot;local.cardiff.2017-05-04&quot;,
@@ -1646,6 +1663,21 @@ A valid postcode search may result in one of 3 outcomes:</p><ul><li><p><a href="
                 &quot;cancelled&quot;: {
                   &quot;type&quot;: &quot;boolean&quot;,
                   &quot;description&quot;: &quot;True if this ballot has been cancelled&quot;
+                },
+                &quot;cancellation_reason&quot;: {
+                  &quot;type&quot;: [
+                    &quot;string&quot;,
+                    &quot;null&quot;
+                  ],
+                  &quot;enum&quot;: [
+                    &quot;NO_CANDIDATES&quot;,
+                    &quot;EQUAL_CANDIDATES&quot;,
+                    &quot;UNDER_CONTESTED&quot;,
+                    &quot;CANDIDATE_DEATH&quot;,
+                    &quot;null&quot;,
+                    null
+                  ],
+                  &quot;description&quot;: &quot;If a ballot has been cancelled, this key may hold a codified reason for that ballot&#x27;s cancellation&quot;
                 },
                 &quot;replaced_by&quot;: {
                   &quot;type&quot;: [
@@ -2855,7 +2887,7 @@ then you can look at the <code>type</code> key.</p><p>The values for this are:</
 finished. This response is a placeholder.</p></li><li><p>(deprecated) <code>voter_id_pilot</code>: over 2018 and 19 some English councils conducted pilots of the voter ID scheme.
 We have replaced this notification with a value per ballot.</p></li></ul><h4>Cancelled Polls</h4><p>Sometimes a scheduled poll may be cancelled. This is usually either because
 the election is uncontested or due to death of a candidate.</p><p>If the user has more than one ballot and only one of them is cancelled, we will not add a notification. In this case,
-you should look at the <code>cancelled</code> value on each ballot.</p><p>If every ballot for a date is cancelled (meaning the user has no election to vote in) then we will add a notification
+you should look at the <code>cancelled</code> and <code>cancellation_reason</code> values on each ballot.</p><p>If every ballot for a date is cancelled (meaning the user has no election to vote in) then we will add a notification
 alerting them that they don't have to vote on that day, e.g:</p><pre><code>{
 ...
   "notifications": [
@@ -2867,28 +2899,8 @@ alerting them that they don't have to vote on that day, e.g:</p><pre><code>{
     }
   ]
 }
-</code></pre><p>In some cases we will know the reason for the cancellation(s). In this case we will add a key to the notification:</p><pre><code>{
-...
-  "notifications": [
-    {
-       "type": "cancelled_election",
-       "title": "Cancelled Election",
-       "url": null,
-       "detail": "The poll for this election will not take place",
-       "cancelled_ballots": [
-           {
-               "ballot_paper_id": "local.foo.2023-02-24",
-               "detail": "Uncontested election with fewer candidates than seats"
-           },
-           {
-               "ballot_paper_id": "pcc.foo.2023-02-24",
-               "detail": "Uncontested election with equal candidates to seats"
-           }
-       ]
-   }
-  ]
-}
-</code></pre><h3>Advance Voting Stations</h3><p>For the 2022 local elections in Wales, four councils are piloting "Advance Voting". This means people in the pilot areas
+</code></pre><p>When we know the reason for a cancelled ballot we will add a <code>cancellation_reason</code> to the ballot object, next to the
+<code>cancelled</code> boolean:</p><ul><li><p><code>NO_CANDIDATES</code>: No candidates</p></li><li><p><code>EQUAL_CANDIDATES</code>: Equal candidates to contested seats</p></li><li><p><code>UNDER_CONTESTED</code>: Fewer candidates than seats</p></li><li><p><code>CANDIDATE_DEATH</code>: Death of a candidate</p></li></ul><h3>Advance Voting Stations</h3><p>For the 2022 local elections in Wales, four councils are piloting "Advance Voting". This means people in the pilot areas
 will be able to cast their vote in the days before polling day.</p><p>We support this pilot, and have an extra key in the API in the <code>dates</code> array.</p><p><pre><code>{
 ...
 "advance_voting_station": {


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1204880927741389/1205170296632729) 

This work aims to remove the old cancellation reason logic and replace it with values imported from other services (namely EE via WDIV). Metadata is no longer routinely used for cancellation reasons no we have this new system in place. 

When all ballots are cancelled for a given election, a notification will be generated breaking down the ballots that have been cancelled as part of that cancelled election and will provide some friendly text based on the cancellation reason code. When 0 < number of cancelled ballots < number of total ballots, there won't be any notifications generated and consumers will be expected to grab the cancellation reason from each individual ballot in the list. 

# To test

_(The reason for all of the setup is that Devs.DC gets a payload from WDIV which isn't stored in the database; it's piped through directly from EE)_

## Setup:
- Make sure you've got a [recent DB dump from EE](https://github.com/DemocracyClub/EveryElection/blob/master/INSTALL.md#set-up-database)
- Bring up EE, WDIV and this project all on different ports
- Find an upcoming ballot and suitable postcode for it 
- In the EE database, set that election to `cancelled=true` and `cancellation_reason='CANDIDATE_DEATH'` (or any other valid cancellation reason)
- In this project, set the EE_BASE_URL and WDIV_BASE_URL to match the ports you brought these up on
- In WDIV, set EE_BASE to match the port you brought it up on

## Testing
- With the suitable postcode you found earlier, make a request to your local Devs.DC /postcode/{postcode}/ endpoint
- You should see that in the `ballots` list your ballot is on there and has this in its structure
```
"cancelled": true,
"cancellation_reason": "CANDIDATE_DEATH",
```
- If the upcoming election you're working with only has one ballot, and it's the ballot you cancelled, then the response should contain the following notifications in the payload (this notification is only generated if all ballots for an election are cancelled)
```
"notifications": [
                {
                    "type": "cancelled_election",
                    "title": "Cancelled Election",
                    "url": null,
                    "detail": "The poll for this election will not take place",
                    "cancelled_ballots": [
                        {
                            "ballot_paper_id": "local.tamworth.amington.by.2023-10-05",
                            "cancellation_reason": "CANDIDATE_DEATH",
                            "detail": {
                                "title": "Uncontested election",
                                "detail": "This election was cancelled due to the death of a candidate. ",
                                "url": null
                            }
                        }
                    ]
                }
            ],
```

```[tasklist]
### PR Checklist
- [x] Note what card in Asana this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Update any documentation
```
