### PR TITLE
Fix sandbox

### DIFF
--- a/.circleci/tests/system/test_app_via_api_gateway.py
+++ b/.circleci/tests/system/test_app_via_api_gateway.py
@@ -27,3 +27,9 @@ def test_api_docs_assets_style_css_filename_contains_md5_of_content(
     styles_file = requests.get(frontend_url + styles_path)
     content_md5_start = hashlib.md5(styles_file.content).hexdigest()[:12]
     assert f".{content_md5_start}." in styles_path
+
+
+def test_sandbox_responses(api_url):
+    base_url = urljoin(api_url, "api/v1/sandbox/postcode/AA11AA/")
+    resp = requests.get(base_url)
+    assert resp.status_code == 200

--- a/api/common/auth_models.py
+++ b/api/common/auth_models.py
@@ -95,6 +95,14 @@ class User:
             rate_limit_warn=api_key_model.rate_limit_warn,
         )
 
+    @classmethod
+    def unauthenticated_user(cls):
+        return cls(
+            user_id="unauthenticated_user",
+            api_key="unauthenticated_user",
+            key_type="unauthenticated_user",
+        )
+
 
 @dataclass
 class ApiPlan:

--- a/api/common/middleware.py
+++ b/api/common/middleware.py
@@ -81,9 +81,7 @@ class APIGatewayAuthenticatorContextMiddleware:
             user = User.from_authorizer_data(authorizer_data)
         elif aws_event:
             # We're on AWS Lambda, but this isn't a function with an authorizer
-            user = User(
-                user_id="unauthenticated_user", api_key="unauthenticated_user"
-            )
+            user = User.unauthenticated_user()
         else:
             # We're not on AWS Lambda
             user = User(

--- a/api/endpoints/v1/sandbox/app.py
+++ b/api/endpoints/v1/sandbox/app.py
@@ -5,24 +5,33 @@ from common.middleware import MIDDLEWARE
 from common.sentry_helper import init_sentry
 from mangum import Mangum
 from starlette.applications import Starlette
-from starlette.responses import FileResponse
+from starlette.responses import FileResponse, Response
 from starlette.routing import Route
 
 init_sentry()
 
 
 def sandbox_content(filename):
-    return Path(__file__).parent / f"sandbox-responses/{filename}.json"
+    path = Path(__file__).parent / f"sandbox-responses/{filename}.json"
+    if not path.exists():
+        raise FileNotFoundError()
+    return path
 
 
 async def sandbox_postcode(request):
-    return FileResponse(
-        sandbox_content(request.path_params["postcode"].upper())
-    )
+    try:
+        return FileResponse(
+            sandbox_content(request.path_params["postcode"].upper())
+        )
+    except FileNotFoundError:
+        return Response(status_code=404)
 
 
 async def sandbox_address(request):
-    return FileResponse(sandbox_content(request.path_params["uprn"]))
+    try:
+        return FileResponse(sandbox_content(request.path_params["uprn"]))
+    except FileNotFoundError:
+        return Response(status_code=404)
 
 
 routes = [

--- a/api/tests/common/test_auth_models.py
+++ b/api/tests/common/test_auth_models.py
@@ -1,0 +1,52 @@
+import json
+
+import httpx
+from common.auth_models import User
+from elections_api_client import wcivf_ballot_cache_url_from_ballot
+from tests.helpers import load_fixture, load_sandbox_output
+from voting_information.app import handler as voting_information_handler
+
+
+def test_unauthenticated():
+    user = User.unauthenticated_user()
+    assert user.user_id == "unauthenticated_user"
+
+
+def test_authentication_via_aws_like_scope(mangum_app_client, respx_mock):
+    """
+    Use Mangum to force the AWS-like scope, so we can test that the
+    authentication middleware is working properly
+    """
+
+    postcode = "AA11AA"
+    fixture = load_fixture("addresspc_endpoints/test_no_elections", "wdiv")
+    respx_mock.get(
+        f"https://wheredoivote.co.uk/api/beta/postcode/{postcode}/"
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json=fixture,
+        )
+    )
+    for ballot in fixture["ballots"]:
+        respx_mock.get(
+            wcivf_ballot_cache_url_from_ballot(ballot["ballot_paper_id"])
+        ).mock(
+            return_value=httpx.Response(
+                200,
+                json=load_fixture(
+                    "addresspc_endpoints/test_no_elections",
+                    ballot["ballot_paper_id"],
+                ),
+            )
+        )
+
+    expected = load_sandbox_output(
+        postcode, base_url="http://testserver/api/v1/"
+    )
+
+    response = mangum_app_client(
+        voting_information_handler, f"/api/v1/postcode/{postcode}/"
+    )
+    assert response["statusCode"] == 200
+    assert json.loads(response["body"]) == expected

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,0 +1,58 @@
+import pytest
+from starlette.testclient import TestClient
+from voting_information.app import app as voting_information_app
+
+
+@pytest.fixture(scope="function")
+def vi_app_client() -> TestClient:
+    with TestClient(app=voting_information_app) as client:
+        yield client
+
+
+@pytest.fixture(scope="function")
+def mangum_app_client():
+    """
+    Use when testing the Mangum integration. Useful when testing
+    in a more Lambda-like environment (e.g when testing Middleware)
+    """
+
+    def _request(handler, url):
+        return handler(make_context_for_url(url), None)
+
+    return _request
+
+
+def make_context_for_url(url):
+    """
+    Makes an AWS-like HTTP context for Mangum.
+    """
+
+    return {
+        "resource": url,
+        "path": url,
+        "httpMethod": "GET",
+        "requestContext": {
+            "resourcePath": url,
+            "httpMethod": "GET",
+            "path": f"/Prod{url}",
+        },
+        "headers": {
+            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+            "accept-encoding": "gzip, deflate, br",
+            "Host": "70ixmpl4fl.execute-api.us-east-2.amazonaws.com",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36",
+            "X-Amzn-Trace-Id": "Root=1-5e66d96f-7491f09xmpl79d18acf3d050",
+        },
+        "multiValueHeaders": {
+            "accept": [
+                "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9"
+            ],
+            "accept-encoding": ["gzip, deflate, br"],
+        },
+        "queryStringParameters": None,
+        "multiValueQueryStringParameters": None,
+        "pathParameters": None,
+        "stageVariables": None,
+        "body": None,
+        "isBase64Encoded": False,
+    }

--- a/api/tests/v1/sandbox/test_sandbox.py
+++ b/api/tests/v1/sandbox/test_sandbox.py
@@ -9,3 +9,9 @@ def test_example_postcodes_load(mangum_app_client, postcode):
     url = f"/api/v1/sandbox/postcode/{postcode}/"
     response = mangum_app_client(sandbox_handler, url)
     assert response["statusCode"] == 200
+
+
+def test_missing_postcode(mangum_app_client):
+    url = "/api/v1/sandbox/postcode/SW1A1AA/"
+    response = mangum_app_client(sandbox_handler, url)
+    assert response["statusCode"] == 404

--- a/api/tests/v1/sandbox/test_sandbox.py
+++ b/api/tests/v1/sandbox/test_sandbox.py
@@ -1,0 +1,11 @@
+import pytest
+from sandbox.app import handler as sandbox_handler
+
+from api.tests.helpers import fixture_map
+
+
+@pytest.mark.parametrize("postcode", fixture_map.keys())
+def test_example_postcodes_load(mangum_app_client, postcode):
+    url = f"/api/v1/sandbox/postcode/{postcode}/"
+    response = mangum_app_client(sandbox_handler, url)
+    assert response["statusCode"] == 200

--- a/api/tests/v1/voting_information/conftest.py
+++ b/api/tests/v1/voting_information/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-from starlette.testclient import TestClient
-from voting_information.app import app
-
-
-@pytest.fixture(scope="function")
-def vi_app_client() -> TestClient:
-    with TestClient(app=app) as client:
-        yield client

--- a/api/tests/v1/voting_information/test_postcode.py
+++ b/api/tests/v1/voting_information/test_postcode.py
@@ -12,9 +12,7 @@ from voting_information.elections_api_client import (
 )
 
 
-@pytest.mark.parametrize(
-    "postcode,input_fixture", [(k, v) for k, v in fixture_map.items()]
-)
+@pytest.mark.parametrize("postcode,input_fixture", list(fixture_map.items()))
 def test_valid(vi_app_client, respx_mock, postcode, input_fixture):
     # iterate through the same set of expected inputs/outputs
     # we test against in test_stitcher.py


### PR DESCRIPTION
Various fixed and improved test coverage for the sandbox API.

1. When called under AWS the `User` model didn't have all the correct parameters passed in. This is currently causing a 500 error on all sandbox pages. This PR adds tests for that code, and does some basic refactoring 
2. When a non-sandbox postcode was requested, a 500 was raised. Now we raise a 404 (this can be tested locally)
3. Add a post-deployment test of the sandbox to ensure it's working in a prod-like environment 