### PR TITLE
Be clear about UPRN types

### DIFF
--- a/api/endpoints/v1/voting_information/address.py
+++ b/api/endpoints/v1/voting_information/address.py
@@ -6,7 +6,7 @@ from stitcher import Stitcher
 
 
 def get_address(request: Request):
-    uprn = request.path_params["uprn"]
+    uprn: str = request.path_params["uprn"]
     client = WdivWcivfApiClient(query_params=request.query_params)
     try:
         wdiv, wcivf = client.get_data_for_address(uprn)

--- a/api/endpoints/v1/voting_information/parl_boundary_changes/client.py
+++ b/api/endpoints/v1/voting_information/parl_boundary_changes/client.py
@@ -70,7 +70,7 @@ class ParlBoundaryChangeApiClient(StaticDataHelper):
 
     def get_data_for_uprn(self):
         return self.get_data_for_postcode().filter(
-            (polars.col("uprn") == self.uprn)
+            (polars.col("uprn") == int(self.uprn))
         )
 
     def is_split(self, data) -> bool:

--- a/api/endpoints/v1/voting_information/stitcher.py
+++ b/api/endpoints/v1/voting_information/stitcher.py
@@ -358,7 +358,7 @@ class Stitcher:
         }
 
         postcode = None
-        uprn = None
+        uprn: Optional[str] = None
         # Get the postcode for the property
         if self.request.path_params.get("postcode"):
             postcode = self.request.path_params.get("postcode")


### PR DESCRIPTION
Hopefully fixes [this error](https://democracy-club-gp.sentry.io/issues/5044717493/?project=1405979&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=1). But it doesn't reproduce locally for me, which I don't really understand. However I changed the dev lambda instance by hand and it fixed the issue. 
 
I've made an assumption that it's better to convert the string to an int, then filter the dataframe, rather than cast the dataframe column to a string. 
s
I think this is safe because the data is generated from WDIV addressbase which doesn't have leading zeros, which is the only reason I can think to treat UPRNs as strings. 