### PR TITLE
Be more clever when showing boundary changes

### DIFF
--- a/api/endpoints/v1/voting_information/parl_boundary_changes/constants.py
+++ b/api/endpoints/v1/voting_information/parl_boundary_changes/constants.py
@@ -1,0 +1,143 @@
+# fmt: off
+OLD_NEW_GSS_TO_UPRN_IN_DIFF_COUNT = {
+    # A Dictionary of (old constituency gss, new constituency gss) tuples to the number of addresses contained in
+    # the symmetrical difference of their boundaries.
+    # This dict includes those old/new pairings that are at least 95% matched.
+    ("gss:E14000650","gss:E14001181"): 0, # Coventry North West / Coventry North West
+    ("gss:E14000763","gss:E14001305"): 0, # Islington North / Islington North
+    ("gss:E14000827","gss:E14001373"): 0, # New Forest East / New Forest East
+    ("gss:E14000652","gss:E14001184"): 0, # Crawley / Crawley
+    ("gss:S14000027","gss:S14000027"): 0, # Na h-Eileanan an Iar / Na h-Eileanan an Iar
+    ("gss:E14000979","gss:E14001528"): 0, # Stretford and Urmston / Stretford and Urmston
+    ("gss:E14000663","gss:E14001194"): 0, # Derby South / Derby South
+    ("gss:E14000755","gss:E14001296"): 0, # Hove / Hove and Portslade
+    ("gss:E14001033","gss:E14001577"): 0, # West Lancashire / West Lancashire
+    ("gss:E14000605","gss:E14001138"): 0, # Bromsgrove / Bromsgrove
+    ("gss:E14000705","gss:E14001240"): 0, # Forest of Dean / Forest of Dean
+    ("gss:E14001004","gss:E14001555"): 0, # Tunbridge Wells / Tunbridge Wells
+    ("gss:E14000962","gss:E14001509"): 0, # St Helens North / St Helens North
+    ("gss:E14000955","gss:E14001499"): 0, # Southampton, Itchen / Southampton Itchen
+    ("gss:E14001052","gss:E14001597"): 0, # Worcester / Worcester
+    ("gss:E14000632","gss:E14001165"): 0, # Chesterfield / Chesterfield
+    ("gss:S14000048","gss:S14000048"): 0, # North Ayrshire and Arran / North Ayrshire and Arran
+    ("gss:E14001058","gss:E14001601"): 0, # Wyre Forest / Wyre Forest
+    ("gss:E14000870","gss:E14001415"): 0, # Oldham East and Saddleworth / Oldham East and Saddleworth
+    ("gss:E14001035","gss:E14001579"): 0, # West Worcestershire / West Worcestershire
+    ("gss:E14000581","gss:E14001113"): 0, # Bootle / Bootle
+    ("gss:E14000682","gss:E14001218"): 0, # East Worthing and Shoreham / East Worthing and Shoreham
+    ("gss:E14000871","gss:E14001416"): 0, # Oldham West and Royton / Oldham West, Chadderton and Royton
+    ("gss:E14000748","gss:E14001287"): 0, # High Peak / High Peak
+    ("gss:S14000021","gss:S14000021"): 0, # East Renfrewshire / East Renfrewshire
+    ("gss:E14000713","gss:E14001252"): 0, # Gosport / Gosport
+    ("gss:S14000058","gss:S14000058"): 0, # West Aberdeenshire and Kincardine / West Aberdeenshire and Kincardine
+    ("gss:S14000010","gss:S14000010"): 0, # Central Ayrshire / Central Ayrshire
+    ("gss:E14000967","gss:E14001515"): 0, # Stalybridge and Hyde / Stalybridge and Hyde
+    ("gss:E14000733","gss:E14001272"): 0, # Hartlepool / Hartlepool
+    ("gss:E14000792","gss:E14001336"): 0, # Lincoln / Lincoln
+    ("gss:E14000589","gss:E14001120"): 0, # Bradford West / Bradford West
+    ("gss:E14000883","gss:E14001431"): 0, # Portsmouth North / Portsmouth North
+    ("gss:S14000045","gss:S14000045"): 0, # Midlothian / Midlothian
+    ("gss:E14000876","gss:E14001423"): 0, # Penistone and Stocksbridge / Penistone and Stocksbridge
+    ("gss:E14000711","gss:E14001246"): 0, # Gillingham and Rainham / Gillingham and Rainham
+    ("gss:E14000982","gss:E14001531"): 0, # Sunderland Central / Sunderland Central
+    ("gss:E14000695","gss:E14001228"): 0, # Erewash / Erewash
+    ("gss:E14000532","gss:E14001065"): 0, # Altrincham and Sale West / Altrincham and Sale West
+    ("gss:E14000959","gss:E14001505"): 0, # Spelthorne / Spelthorne
+    ("gss:E14000758","gss:E14001299"): 0, # Hyndburn / Hyndburn
+    ("gss:E14000939","gss:E14001487"): 0, # South Holland and The Deepings / South Holland and The Deepings
+    ("gss:E14000828","gss:E14001374"): 0, # New Forest West / New Forest West
+    ("gss:E14000838","gss:E14001387"): 0, # North Devon / North Devon
+    ("gss:E14000854","gss:E14001400"): 0, # North Warwickshire / North Warwickshire and Bedworth
+    ("gss:W07000041","gss:W07000112"): 0, # Ynys Môn / Ynys Môn
+    ("gss:E14000761","gss:E14001302"): 0, # Ipswich / Ipswich
+    ("gss:E14000715","gss:E14001254"): 0, # Gravesham / Gravesham
+    ("gss:E14001039","gss:E14001585"): 0, # Wigan / Wigan
+    ("gss:E14001059","gss:E14001602"): 0, # Wythenshawe and Sale East / Wythenshawe and Sale East
+    ("gss:E14000610","gss:E14001143"): 0, # Burton / Burton and Uttoxeter
+    ("gss:E14000956","gss:E14001500"): 0, # Southampton, Test / Southampton Test
+    ("gss:E14001013","gss:E14001563"): 0, # Walthamstow / Walthamstow
+    ("gss:E14000717","gss:E14001256"): 0, # Great Yarmouth / Great Yarmouth
+    ("gss:E14000802","gss:E14001347"): 0, # Macclesfield / Macclesfield
+    ("gss:E14000736","gss:E14001275"): 0, # Havant / Havant
+    ("gss:E14000662","gss:E14001193"): 0, # Derby North / Derby North
+    ("gss:E14000884","gss:E14001432"): 0, # Portsmouth South / Portsmouth South
+    ("gss:E14000618","gss:E14001150"): 0, # Cannock Chase / Cannock Chase
+    ("gss:E14000868","gss:E14001413"): 0, # Nuneaton / Nuneaton
+    ("gss:E14000627","gss:E14001158"): 0, # Cheadle / Cheadle
+    ("gss:E14000693","gss:E14001226"): 0, # Epping Forest / Epping Forest
+    ("gss:E14000913","gss:E14001461"): 0, # Scarborough and Whitby / Scarborough and Whitby
+    ("gss:S14000008","gss:S14000008"): 1, # Berwickshire, Roxburgh and Selkirk / Berwickshire, Roxburgh and Selkirk
+    ("gss:S14000040","gss:S14000040"): 2, # Kilmarnock and Loudoun / Kilmarnock and Loudoun
+    ("gss:S14000006","gss:S14000006"): 2, # Ayr, Carrick and Cumnock / Ayr, Carrick and Cumnock
+    ("gss:S14000025","gss:S14000081"): 4, # Edinburgh South West / Edinburgh South West
+    ("gss:E14000925","gss:E14001472"): 4, # Shipley / Shipley
+    ("gss:E14000766","gss:E14001308"): 4, # Keighley / Keighley and Ilkley
+    ("gss:E14000737","gss:E14001276"): 5, # Hayes and Harlington / Hayes and Harlington
+    ("gss:E14000985","gss:E14001535"): 7, # Sutton Coldfield / Sutton Coldfield
+    ("gss:E14000998","gss:E14001550"): 7, # Tooting / Tooting
+    ("gss:S14000051","gss:S14000051"): 19, # Orkney and Shetland / Orkney and Shetland
+    ("gss:E14000845","gss:E14001393"): 24, # North East Hertfordshire / North East Hertfordshire
+    ("gss:E14000968","gss:E14001516"): 24, # Stevenage / Stevenage
+    ("gss:E14000779","gss:E14001321"): 25, # Leeds North East / Leeds North East
+    ("gss:E14000533","gss:E14001066"): 43, # Amber Valley / Amber Valley
+    ("gss:E14000584","gss:E14001115"): 76, # Bournemouth East / Bournemouth East
+    ("gss:E14000835","gss:E14001381"): 77, # Newton Abbot / Newton Abbot
+    ("gss:E14000594","gss:E14001125"): 100, # Brentwood and Ongar / Brentwood and Ongar
+    ("gss:E14001017","gss:E14001564"): 112, # Warrington North / Warrington North
+    ("gss:E14000984","gss:E14001534"): 162, # Sutton and Cheam / Sutton and Cheam
+    ("gss:E14000621","gss:E14001153"): 162, # Carshalton and Wallington / Carshalton and Wallington
+    ("gss:E14000938","gss:E14001486"): 262, # South East Cornwall / South East Cornwall
+    ("gss:E14000670","gss:E14001202"): 403, # Dover / Dover and Deal
+    ("gss:E14000703","gss:E14001238"): 510, # Finchley and Golders Green / Finchley and Golders Green
+    ("gss:E14000577","gss:E14001109"): 605, # Bolsover / Bolsover
+    ("gss:E14000843","gss:E14001391"): 605, # North East Derbyshire / North East Derbyshire
+    ("gss:E14000878","gss:E14001425"): 650, # Peterborough / Peterborough
+    ("gss:E14000597","gss:E14001129"): 691, # Brighton, Kemptown / Brighton Kemptown and Peacehaven
+    ("gss:E14000598","gss:E14001130"): 691, # Brighton, Pavilion / Brighton Pavilion
+    ("gss:E14000999","gss:E14001551"): 774, # Torbay / Torbay
+    ("gss:E14000900","gss:E14001448"): 799, # Romford / Romford
+    ("gss:E14000675","gss:E14001208"): 903, # Ealing North / Ealing North
+    ("gss:E14000847","gss:E14001395"): 1111, # North Herefordshire / North Herefordshire
+    ("gss:E14000743","gss:E14001281"): 1111, # Hereford and South Herefordshire / Hereford and South Herefordshire
+    ("gss:E14000989","gss:E14001541"): 1210, # Telford / Telford
+    ("gss:E14000623","gss:E14001155"): 1299, # Central Devon / Central Devon
+    ("gss:S14000059","gss:S14000106"): 1417, # West Dunbartonshire / West Dunbartonshire
+    ("gss:E14000805","gss:E14001350"): 1420, # Makerfield / Makerfield
+    ("gss:E14000707","gss:E14001243"): 1432, # Gainsborough / Gainsborough
+    ("gss:E14000864","gss:E14001409"): 1433, # Norwich South / Norwich South
+    ("gss:E14000565","gss:E14001097"): 1433, # Birmingham, Northfield / Birmingham Northfield
+    ("gss:E14000587","gss:E14001118"): 1504, # Bradford East / Bradford East
+    ("gss:E14000588","gss:E14001119"): 1504, # Bradford South / Bradford South
+    ("gss:N06000006","gss:N05000006"): 1513, # East Londonderry / East Londonderry
+    ("gss:E14000902","gss:E14001450"): 1552, # Rossendale and Darwen / Rossendale and Darwen
+    ("gss:E14000570","gss:E14001102"): 1552, # Blackburn / Blackburn
+    ("gss:E14000921","gss:E14001466"): 1616, # Sheffield, Brightside and Hillsborough / Sheffield Brightside and Hillsborough
+    ("gss:E14000905","gss:E14001453"): 1636, # Rugby / Rugby
+    ("gss:E14000614","gss:E14001147"): 1862, # Calder Valley / Calder Valley
+    ("gss:E14000881","gss:E14001429"): 1914, # Poole / Poole
+    ("gss:E14001062","gss:E14001605"): 2026, # York Outer / York Outer
+    ("gss:N06000013","gss:N05000013"): 2093, # North Down / North Down
+    ("gss:E14000751","gss:E14001292"): 2237, # Hornchurch and Upminster / Hornchurch and Upminster
+    ("gss:N06000014","gss:N05000014"): 2369, # South Antrim / South Antrim
+    ("gss:E14000922","gss:E14001468"): 2391, # Sheffield, Hallam / Sheffield Hallam
+    ("gss:E14000880","gss:E14001427"): 2474, # Plymouth, Sutton and Devonport / Plymouth Sutton and Devonport
+    ("gss:E14000879","gss:E14001426"): 2474, # Plymouth, Moor View / Plymouth Moor View
+    ("gss:E14000806","gss:E14001351"): 2659, # Maldon / Maldon
+    ("gss:E14000712","gss:E14001248"): 2843, # Gloucester / Gloucester
+    ("gss:S14000013","gss:S14000073"): 2905, # Dumfries and Galloway / Dumfries and Galloway
+    ("gss:E14000928","gss:E14001475"): 3322, # Skipton and Ripon / Skipton and Ripon
+    ("gss:E14000896","gss:E14001445"): 3959, # Richmond Park / Richmond Park
+    ("gss:E14000995","gss:E14001546"): 4275, # Thurrock / Thurrock
+    ("gss:E14000544","gss:E14001077"): 4294, # Basildon and Billericay / Basildon and Billericay
+    ("gss:S14000003","gss:S14000063"): 4418, # Airdrie and Shotts / Airdrie and Shotts
+    ("gss:E14000754","gss:E14001295"): 5074, # Houghton and Sunderland South / Houghton and Sunderland South
+    ("gss:E14000898","gss:E14001447"): 5779, # Rochester and Strood / Rochester and Strood
+    ("gss:S14000049","gss:S14000100"): 5991, # North East Fife / North East Fife
+    ("gss:E14000851","gss:E14001536"): 7449, # North Swindon / Swindon North
+    ("gss:E14000820","gss:E14001368"): 7950, # Middlesbrough South and East Cleveland / Middlesbrough South and East Cleveland
+    ("gss:S14000026","gss:S14000082"): 8253, # Edinburgh West / Edinburgh West
+    ("gss:S14000020","gss:S14000096"): 8561, # East Lothian / Lothian East
+    ("gss:E14000645","gss:E14001177"): 8940, # Colne Valley / Colne Valley
+    ("gss:E14000600","gss:E14001134"): 11016, # Bristol North West / Bristol North West
+    ("gss:W07000068","gss:W07000085"): 11319, # Brecon and Radnorshire / Brecon, Radnor and Cwm Tawe
+} # fmt: on

--- a/api/endpoints/v1/voting_information/parl_boundary_changes/models.py
+++ b/api/endpoints/v1/voting_information/parl_boundary_changes/models.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Optional
 
+from parl_boundary_changes.constants import OLD_NEW_GSS_TO_UPRN_IN_DIFF_COUNT
 from polars import DataFrame
 from static_data_helper import BaseDictDataclass, BaseResponse
 
@@ -14,8 +15,21 @@ class BaseParlBoundaryChange(BaseDictDataclass):
 
     @property
     def change_type(self):
-        if self.new_constituencies_official_identifier == "gss:E14001302":
-            # Ipswich has a new GSS code but there is no change to the name or boundary.
+        if (
+            self.current_constituencies_official_identifier
+            == self.new_constituencies_official_identifier
+        ):
+            return "NO_CHANGE"
+        if (
+            uprn_count := OLD_NEW_GSS_TO_UPRN_IN_DIFF_COUNT.get(
+                (
+                    self.current_constituencies_official_identifier,
+                    self.new_constituencies_official_identifier,
+                ),
+                None,
+            )
+        ) and uprn_count < 50:
+            # We could be more clever here and introduce 'MINOR_CHANGE'
             return "NO_CHANGE"
         CHANGE_TYPE = []
         if self.new_constituencies_name != self.current_constituencies_name:


### PR DESCRIPTION
Context - gss codes have changed in a lot of places where the boundaries of new constituencies haven't changed. In addition boundaries have changed in ways that don't effect who votes - i.e. rivers, high tide lines, chunks of moorland etc.

Solution - Take the new constituency which has greatest overlap to each old constituency. Take the symmetrical difference of these, and see how many properties fall in that differnce. If the number of properties is below some threshold (50), then declare `NO_CHANGE` for lookups with that old/new pair. This means that the edge cases - i.e. the small number of addresses that are in only one out of the old/new pair will be told about the big change that has effected them.

Has changes:
`http://127.0.0.1:8000/api/v1/address/200000387440/?parl_boundaries=1`

```
"parl_boundary_changes":{"current_constituencies_official_identifier":"gss:E14000814","current_constituencies_name":"Mid Derbyshire","new_constituencies_official_identifier":"gss:E14001066","new_constituencies_name":"Amber Valley","CHANGE_TYPE":"NAME_CHANGE_BOUNDARY_CHANGE"}
```

Doesn't have changes:
`http://127.0.0.1:8000/api/v1/address/100030011757/?parl_boundaries=1`

```
"parl_boundary_changes":{"current_constituencies_official_identifier":"gss:E14000533","current_constituencies_name":"Amber Valley","new_constituencies_official_identifier":"gss:E14001066","new_constituencies_name":"Amber Valley","CHANGE_TYPE":"NO_CHANGE"}
```


![image](https://github.com/DemocracyClub/aggregator-api/assets/20044500/bfa9fa77-b85f-462c-9175-de32be93c414)
