### PR TITLE
Show "NO_CHANGE" response if number of addresses changed is zero

### DIFF
--- a/api/endpoints/v1/voting_information/parl_boundary_changes/models.py
+++ b/api/endpoints/v1/voting_information/parl_boundary_changes/models.py
@@ -28,6 +28,7 @@ class BaseParlBoundaryChange(BaseDictDataclass):
                 ),
                 None,
             )
+            is not None
         ) and uprn_count < 50:
             # We could be more clever here and introduce 'MINOR_CHANGE'
             return "NO_CHANGE"


### PR DESCRIPTION
Previously we were checking for the boolean value of the look up. If the tuple was found, but the addresses changed were zero that zero would evaluate to False.

This change checks for None rather than bool(value).


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207650479999935