### PR TITLE
WIP reject fake host headers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
                AppIsBehindCloudFront=True \
                AppLogRetentionDays=60 \
                DCEnvironment=$DC_ENVIRONMENT \
-
+               AppDomain='$PUBLIC_FQDN' \
               "
 
     - run:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lambda-layers/FrontendDependenciesLayer/requirements.txt: Pipfile Pipfile.lock #
 
 .PHONY: aggregator/apps/api_docs/v1/templates/api_docs_rendered.html
 aggregator/apps/api_docs/v1/templates/api_docs_rendered.html: ## Rebuild the API documentation page
-	PIPELINE_ENABLED=True python manage.py build_docs
+	PIPELINE_ENABLED=True APP_DOMAIN=localhost python manage.py build_docs
 
 .PHONY: help
 # gratuitously adapted from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html

--- a/frontend/settings/base_lambda.py
+++ b/frontend/settings/base_lambda.py
@@ -1,8 +1,19 @@
 import os
 
-from boto3 import Session
+import boto3
 
 from .base import *  # noqa
+
+
+def get_api_gateway_urls():
+    client = boto3.client("apigateway")
+    response = client.get_rest_apis()
+    return [
+        f"{api['id']}.execute-api.eu-west-2.amazonaws.com"
+        for api in response["items"]
+        if api["name"].startswith("AggregatorApiApp-")
+    ]
+
 
 ALLOWED_HOSTS = [os.environ.get("APP_DOMAIN")]
 DEBUG = os.environ.get("DEBUG", False)
@@ -71,7 +82,8 @@ PIPELINE["COMPILERS"] = (  # noqa
 )
 
 if os.environ.get("AWS_EXECUTION_ENV"):
-    logger_boto3_session = Session(region_name="eu-west-2")
+    ALLOWED_HOSTS = ALLOWED_HOSTS + get_api_gateway_urls()
+    logger_boto3_session = boto3.Session(region_name="eu-west-2")
 
     LOGGING = {
         "version": 1,

--- a/frontend/settings/base_lambda.py
+++ b/frontend/settings/base_lambda.py
@@ -4,7 +4,7 @@ from boto3 import Session
 
 from .base import *  # noqa
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = [os.environ.get("APP_DOMAIN")]
 DEBUG = os.environ.get("DEBUG", False)
 
 WHITENOISE_AUTOREFRESH = False

--- a/template.yaml
+++ b/template.yaml
@@ -20,6 +20,10 @@ Parameters:
     Default: AppDebug
     Type: AWS::SSM::Parameter::Value<String>
 
+  AppDomain:
+    Description: "The domain the app is on."
+    Type: String
+
   AppSentryDSN:
     Description: "The SENTRY_DSN environment variable passed to the app."
     Type: String
@@ -322,6 +326,7 @@ Resources:
           SMTP_HOST: !Ref AppSmtpHost
           SMTP_USERNAME: !Ref AppSmtpUser
           SMTP_PASSWORD: !Ref AppSmtpPass
+          APP_DOMAIN: !Ref AppDomain
       Events:
         HTTPRequests:
           Type: Api


### PR DESCRIPTION
OK. I'm a bit stuck here.

Currently this application allows anything in the host header. This makes the site vulnerable to a range of spoofing attacks. I want to tighten this up.

The changes in https://github.com/DemocracyClub/aggregator-api/commit/f680c9a8026cba86cc7a47951b646032ea675e66 achieve this. However, they cause another problem.

When we deploy this app, we bring the lambda up and then run some smoke tests against it before we finalise the deploy. Because at the stage we're running the smoke tests, we haven't pointed the DNS at it yet, we have to test this on a direct URL i.e: we have to call https://fig9r88dhk.execute-api.eu-west-2.amazonaws.com/Prod/ rather than https://developers.womblelabs.co.uk/ or whatever.

That means those URLs also have to be in ALLOWED_HOSTS, otherwise we raise `400 Bad Request` in the smoke tests.

So my first bash at a fix for this is https://github.com/DemocracyClub/aggregator-api/commit/fe21b9649539d749704472dfbd32900698304379. In theory that should work. Unfortunately, when we try to run that code on lambda I get

```
ClientError: An error occurred (AccessDeniedException) when calling the GetRestApis operation: User: arn:aws:sts::489559689862:assumed-role/AggregatorApiLambdaExecutionRole/AggregatorApiApp-development-ApiFrontendFunction-KHzbY2EsfvyY is not authorized to perform: apigateway:GET on resource: arn:aws:apigateway:eu-west-2::/restapis because no identity-based policy allows the apigateway:GET action
```

so in order to get that to work, I need to grant our `AggregatorApiLambdaExecutionRole`s the ability to perform that action but I'm unclear on how permissions are managed in this application. It looks from the docs like this was probably done as a one-off rather than as part of the deploy process.

The other thing we could consider doing is just setting the IDs as env vars. We can't use the `AggregatorApiFrontendFqdn` output to set an env var because we have to define the env vars before that output is available. I'm slightly less clear on `ServerlessRestApi`. I don't think I can really explain where that comes from.

I think this would be a good one for us to catch up on next week @symroe