### PR TITLE
removes temporary  output

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -418,12 +418,6 @@ Outputs:
     Export:
       Name: !Join [ ":", [ !Ref "AWS::StackName", "AggregatorApiFrontendFqdn" ] ]
 
-  AggregatorApiFrontendFqdnTempValue:
-    Description: "API Gateway endpoint FQDN for Aggregator API function"
-    Value: !Sub "${FrontendAPIGateway}.execute-api.${AWS::Region}.amazonaws.com"
-    Export:
-      Name: !Join [ ":", [ !Ref "AWS::StackName", "AggregatorApiFrontendFqdnTempValue" ] ]
-
   AggregatorApiFqdn:
     Description: "API Gateway endpoint FQDN for Aggregator API function"
     Value: !Sub "${DCAPI}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
This was part of removing the intrinsic api gateway and is now no longer in use.