### PR TITLE
Get dc_environment from env not settings

### DIFF
--- a/api/frontend/frontend/apps/api_users/logging_helpers.py
+++ b/api/frontend/frontend/apps/api_users/logging_helpers.py
@@ -1,10 +1,10 @@
 import csv
 import logging
+import os
 from dataclasses import dataclass
 from io import StringIO
 
 import boto3
-from django.conf import settings
 
 logger = logging.getLogger()
 
@@ -19,7 +19,7 @@ class APIKeyForLogging:
 
     @property
     def dc_environment(self):
-        return getattr(settings, "DC_ENVIRONMENT", None)
+        return os.environ.get("DC_ENVIRONMENT", None)
 
     @property
     def file_name(self):

--- a/api/frontend/frontend/apps/api_users/management/commands/write_api_key_csvs_to_monitoring_s3.py
+++ b/api/frontend/frontend/apps/api_users/management/commands/write_api_key_csvs_to_monitoring_s3.py
@@ -8,7 +8,11 @@ s3_client = boto3.client("s3")
 
 
 class Command(BaseCommand):
-    help = "Writes a onerow csv per api key to S3"
+    help = (
+        "Writes a onerow csv per api key to S3. "
+        "Run from your local machine with prod db settings"
+        "eg AWS_PROFILE=prod-aggregatorapi-dc DC_ENVIRONMENT=production python manage.py write_api_key_csvs_to_monitoring_s3"
+    )
 
     def handle(self, **options):
         for key in APIKey.objects.all().select_related("user"):

--- a/api/frontend/frontend/apps/api_users/tests/test_logging_helpers.py
+++ b/api/frontend/frontend/apps/api_users/tests/test_logging_helpers.py
@@ -6,8 +6,14 @@ import pytest
 from api_users.logging_helpers import APIKeyForLogging
 from api_users.models import APIKey
 from django.contrib.auth import get_user_model
-from django.test.utils import override_settings
 from moto import mock_aws
+
+
+def _set_dc_environment(monkeypatch, env):
+    if env is None:
+        monkeypatch.delenv("DC_ENVIRONMENT", raising=False)
+    else:
+        monkeypatch.setenv("DC_ENVIRONMENT", env)
 
 
 @pytest.fixture
@@ -85,9 +91,9 @@ def test_file_name(api_key):
         ("other", "api-users/aggregator-api/local-dev/latest/"),
     ],
 )
-def test_prefix(api_key, env, expected):
-    with override_settings(DC_ENVIRONMENT=env):
-        assert api_key.prefix == expected
+def test_prefix(api_key, env, expected, monkeypatch):
+    _set_dc_environment(monkeypatch, env)
+    assert api_key.prefix == expected
 
 
 @pytest.mark.parametrize(
@@ -100,16 +106,23 @@ def test_prefix(api_key, env, expected):
         ("other", "local-dev-logging"),
     ],
 )
-def test_bucket(api_key, env, expected):
-    with override_settings(DC_ENVIRONMENT=env):
-        assert api_key.bucket == expected
+def test_bucket(api_key, env, expected, monkeypatch):
+    _set_dc_environment(monkeypatch, env)
+    assert api_key.bucket == expected
 
 
 @pytest.mark.parametrize("env", ["production", "development", "staging"])
 def test_upload_to_s3_deployed(
-    api_key, s3_client, s3_prod_bucket, s3_dev_bucket, env, caplog
+    api_key,
+    s3_client,
+    s3_prod_bucket,
+    s3_dev_bucket,
+    env,
+    caplog,
+    monkeypatch,
 ):
-    with override_settings(DC_ENVIRONMENT=env), mock_aws():
+    _set_dc_environment(monkeypatch, env)
+    with mock_aws():
         # Upload the file
         destination = api_key.upload_to_s3()
         expected_destination = (
@@ -141,9 +154,9 @@ def test_upload_to_s3_deployed(
     assert row[4] == api_key.usage_reason
 
 
-def test_upload_to_s3_local(api_key, caplog):
-    with override_settings(DC_ENVIRONMENT=None):
-        destination = api_key.upload_to_s3()
+def test_upload_to_s3_local(api_key, caplog, monkeypatch):
+    _set_dc_environment(monkeypatch, None)
+    destination = api_key.upload_to_s3()
     expected_destination = (
         f"s3://{api_key.bucket}/{api_key.prefix}{api_key.file_name}"
     )


### PR DESCRIPTION
Should run the sync command just after merging.

In the lambda the DC_ENVIRONMENT exists as an environment variable, and that's how we access it elsewhere ([example](https://github.com/DemocracyClub/aggregator-api/blob/f21c47dca43b7faff19f968820d911b5950f8789/common/common/sentry_helper.py#L12)). So have just copied that here.

Doing some more code search I think there should be a setting `DC_ENVIRONMENT` ([src](https://github.com/DemocracyClub/aggregator-api/blob/f21c47dca43b7faff19f968820d911b5950f8789/common/common/conf.py#L19)). But not sure it really matters whether we use it here. 