### PR TITLE
wrap upstream errors on /elections endpoint

### DIFF
--- a/api/endpoints/v1/elections/election_views.py
+++ b/api/endpoints/v1/elections/election_views.py
@@ -4,16 +4,24 @@ from starlette.responses import JSONResponse
 from static_elections_client import ElectionsForPostcodeHelper
 from voting_information_api_client import EEApiClient
 
+from common.async_requests import UpstreamApiError
+
 
 async def get_election_list(request: Request):
     client = EEApiClient(request.base_url)
-    result = await client.get_election_list(request.query_params)
+    try:
+        result = await client.get_election_list(request.query_params)
+    except UpstreamApiError as error:
+        return JSONResponse(error.message, status_code=error.status)
     return JSONResponse(result)
 
 
 async def get_single_election(request: Request):
     client = EEApiClient(request.base_url)
-    result = await client.get_single_election(request.path_params["slug"])
+    try:
+        result = await client.get_single_election(request.path_params["slug"])
+    except UpstreamApiError as error:
+        return JSONResponse(error.message, status_code=error.status)
     return JSONResponse(result)
 
 

--- a/tests/v1/elections/test_elections_api_client.py
+++ b/tests/v1/elections/test_elections_api_client.py
@@ -44,6 +44,23 @@ def test_clean_query_params(elections_app_client):
 
 
 @pytest.mark.asyncio
+async def test_get_election_list_upstream_error(
+    respx_mock, elections_app_client
+):
+    respx_mock.get(
+        "https://elections.democracyclub.org.uk/api/elections/"
+    ).mock(
+        return_value=httpx.Response(
+            404,
+            json={"detail": "Not found."},
+        )
+    )
+    response = elections_app_client.get("/api/v1/elections/")
+    assert response.status_code == 404
+    assert response.json() == {"error": "Not found."}
+
+
+@pytest.mark.asyncio
 async def test_get_election_list(respx_mock, elections_app_client):
     respx_mock.get(
         "https://elections.democracyclub.org.uk/api/elections/"
@@ -60,6 +77,22 @@ async def test_get_election_list(respx_mock, elections_app_client):
         "elections_endpoint/test_every_election_list", "expected_output"
     )
     assert expected == response.json()
+
+
+def test_get_single_election_upstream_error(respx_mock, elections_app_client):
+    respx_mock.get(
+        "https://elections.democracyclub.org.uk/api/elections/not-a-real-election/"
+    ).mock(
+        return_value=httpx.Response(
+            404,
+            json={"detail": "Not found."},
+        )
+    )
+    response = elections_app_client.get(
+        "/api/v1/elections/not-a-real-election/"
+    )
+    assert response.status_code == 404
+    assert response.json() == {"error": "Not found."}
 
 
 def test_get_single_election(respx_mock, elections_app_client):


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1214889435971321?focus=true

Quick change to wrap errors from the upstream. This brings /elections into line with the behaviour of `/postcode` and `/address`